### PR TITLE
feat[progress-bar]: allow slot for indeterminate value

### DIFF
--- a/packages/openbridge-webcomponents/src/components/elevated-card-radio-group/elevated-card-radio-group.ts
+++ b/packages/openbridge-webcomponents/src/components/elevated-card-radio-group/elevated-card-radio-group.ts
@@ -5,6 +5,10 @@ import {ObcElevatedCardPosition} from '../elevated-card/elevated-card.js';
 import '../elevated-card-radio/elevated-card-radio.js';
 import {customElement} from '../../decorator.js';
 
+export type ObcElevatedCardRadioGroupChangeEvent = CustomEvent<{
+  value: string;
+}>;
+
 /**
  * `<obc-elevated-card-radio-group>` – A group of radio buttons styled as elevated cards for single selection.
  *
@@ -76,7 +80,7 @@ import {customElement} from '../../decorator.js';
  * In this example, "Option B" is pre-selected, and the group is required.
  *
  * @slot - No named slots. All content is provided via the `options` property.
- * @fires change - Dispatched when the value changes. Event detail: `{ value: string }`
+ * @fires change {ObcElevatedCardRadioGroupChangeEvent} - Dispatched when the value changes
  */
 @customElement('obc-elevated-card-radio-group')
 export class ObcElevatedCardRadioGroup extends LitElement {
@@ -117,7 +121,11 @@ export class ObcElevatedCardRadioGroup extends LitElement {
   private _handleValueChange(params: InputEvent) {
     const value = (params.target as HTMLInputElement).value;
     this.value = value;
-    this.dispatchEvent(new CustomEvent('change', {detail: {value}}));
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        detail: {value},
+      }) satisfies ObcElevatedCardRadioGroupChangeEvent
+    );
   }
 
   override render() {

--- a/packages/openbridge-webcomponents/src/components/progress-bar/progress-bar.ts
+++ b/packages/openbridge-webcomponents/src/components/progress-bar/progress-bar.ts
@@ -161,7 +161,9 @@ export class ObcProgressBar extends LitElement {
     } else if (this.circularState === CircularProgressState.indeterminate) {
       return html`
         <div class="circular-label-container">
-          <span class="circular-value">...</span>
+          <span class="circular-value">
+            <slot name="icon">...</slot>
+          </span>
         </div>
       `;
     } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an `icon` slot for the circular indeterminate progress bar and types the `change` event for the elevated card radio group.
> 
> - **Components**:
>   - **`obc-progress-bar`** (circular, indeterminate):
>     - Adds named slot `slot="icon"` inside circular label to customize the indeterminate indicator (fallback `...`).
>   - **`obc-elevated-card-radio-group`**:
>     - Exports `ObcElevatedCardRadioGroupChangeEvent` type and applies it to the dispatched `change` event.
>     - Updates JSDoc `@fires` to reference the typed event.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 203e551a1a5394303ed8aa89688f8e6ba27097a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->