### PR TITLE
fix[azimuth-thruster]: not rendring in firefox

### DIFF
--- a/packages/openbridge-webcomponents/src/navigation-instruments/azimuth-thruster/azimuth-thruster.css
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/azimuth-thruster/azimuth-thruster.css
@@ -2,14 +2,14 @@
   box-sizing: border-box;
 }
 
-:host {
+.container {
   display: block;
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-:host > * {
+.container > * {
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/openbridge-webcomponents/src/navigation-instruments/azimuth-thruster/azimuth-thruster.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/azimuth-thruster/azimuth-thruster.ts
@@ -173,35 +173,37 @@ export class ObcAzimuthThruster extends LitElement {
     }
 
     return html`
-      <obc-watch
-        .tickmarks=${tickmarks}
-        .state=${this.state}
-        .angleSetpoint=${this.angleSetpoint}
-        .atAngleSetpoint=${this.atAngleSetpointCalc}
-        .tickmarksInside=${this.tickmarksInside}
-        padding=${ifDefined(this.noPadding ? 16 : undefined)}
-        .advices=${this.angleAdviceRaw}
-        .starboardPortIndicator=${this.starboardPortIndicator}
-      ></obc-watch>
-      <svg viewBox=${viewBox} xmlns="http://www.w3.org/2000/svg">
-        <g transform="rotate(${rotateAngle})">
-          ${thruster(this.thrust, this.thrustSetpoint, this.state, {
-            atSetpoint: this.atThrustSetpoint,
-            singleSided: true,
-            singleDirection: false,
-            singleDirectionHalfSize: this.singleDirection,
-            tunnel: false,
-            autoAtSetpoint: !this.disableAutoAtThrustSetpoint,
-            autoSetpointDeadband: this.autoAtThrustSetpointDeadband,
-            setpointAtZeroDeadband: this.thrustSetpointAtZeroDeadband,
-            touching: this.touching,
-            advices: this.thrustAdvices,
-            topPropeller: this.topPropeller,
-            bottomPropeller: this.bottomPropeller,
-            narrow: true,
-          })}
-        </g>
-      </svg>
+      <div class="container">
+        <obc-watch
+          .tickmarks=${tickmarks}
+          .state=${this.state}
+          .angleSetpoint=${this.angleSetpoint}
+          .atAngleSetpoint=${this.atAngleSetpointCalc}
+          .tickmarksInside=${this.tickmarksInside}
+          padding=${ifDefined(this.noPadding ? 16 : undefined)}
+          .advices=${this.angleAdviceRaw}
+          .starboardPortIndicator=${this.starboardPortIndicator}
+        ></obc-watch>
+        <svg viewBox=${viewBox} xmlns="http://www.w3.org/2000/svg">
+          <g transform="rotate(${rotateAngle})">
+            ${thruster(this.thrust, this.thrustSetpoint, this.state, {
+              atSetpoint: this.atThrustSetpoint,
+              singleSided: true,
+              singleDirection: false,
+              singleDirectionHalfSize: this.singleDirection,
+              tunnel: false,
+              autoAtSetpoint: !this.disableAutoAtThrustSetpoint,
+              autoSetpointDeadband: this.autoAtThrustSetpointDeadband,
+              setpointAtZeroDeadband: this.thrustSetpointAtZeroDeadband,
+              touching: this.touching,
+              advices: this.thrustAdvices,
+              topPropeller: this.topPropeller,
+              bottomPropeller: this.bottomPropeller,
+              narrow: true,
+            })}
+          </g>
+        </svg>
+      </div>
     `;
   }
 


### PR DESCRIPTION
Fixes #413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch render to `html` and adjust `obc-watch` bindings plus CSS update to fix Firefox rendering.
> 
> - **Azimuth Thruster (`azimuth-thruster.ts`)**:
>   - Switch template tag from `svg` to `html` and update import accordingly.
>   - Change `obc-watch` `padding` from property binding to attribute (`padding=${ifDefined(...)}`).
> - **Styles (`azimuth-thruster.css`)**:
>   - Add `display: block` to `.container` and ensure children are absolutely positioned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c83e16437cdd46872332f7d5a2212cce34b19c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->