### PR TITLE
refactor: add message menu item slot fallback

### DIFF
--- a/packages/openbridge-webcomponents/src/components/message-menu-item/message-menu-item.ts
+++ b/packages/openbridge-webcomponents/src/components/message-menu-item/message-menu-item.ts
@@ -141,9 +141,9 @@ export class ObcMessageMenuItem extends LitElement {
   @property({type: Boolean}) hasTrailingIcon = false;
   @property({type: Boolean}) isShelved = false;
 
-  `@property`({type: Boolean}) hasTitleSlot = false;
-  `@property`({type: Boolean}) hasDescriptionSlot = false;
-  `@property`({type: Boolean}) hasActionLabelSlot = false;
+  @property({type: Boolean}) hasTitleSlot = false;
+  @property({type: Boolean}) hasDescriptionSlot = false;
+  @property({type: Boolean}) hasActionLabelSlot = false;
 
   private get activeSize() {
     if (this.open) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message menu items now support optional title, description, and action-label slots for richer, customizable content.
  * Primary action detection now recognizes either a text label or an action-label slot, ensuring actions display when slot content is provided.

* **Documentation**
  * Updated docs and examples showing slot usage, new slot names, and examples for rich HTML content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->