### PR TITLE
Add bubling to change events to expose outside of shadow DOM

### DIFF
--- a/packages/openbridge-webcomponents/src/components/elevated-card-radio-group/elevated-card-radio-group.ts
+++ b/packages/openbridge-webcomponents/src/components/elevated-card-radio-group/elevated-card-radio-group.ts
@@ -124,6 +124,8 @@ export class ObcElevatedCardRadioGroup extends LitElement {
     this.dispatchEvent(
       new CustomEvent('change', {
         detail: {value},
+        bubbles: true,
+        composed: true,
       }) satisfies ObcElevatedCardRadioGroupChangeEvent
     );
   }

--- a/packages/openbridge-webcomponents/src/components/radio/radio.ts
+++ b/packages/openbridge-webcomponents/src/components/radio/radio.ts
@@ -187,7 +187,12 @@ export class ObcRadio extends LitElement {
 
   onChange(event: Event) {
     event.stopPropagation();
-    this.dispatchEvent(new CustomEvent('change'));
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   override render() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated radio and elevated-card radio group components so their change events now properly propagate (including across shadow DOM), improving event listener reliability and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->