### PR TITLE
fix[elevated-radio-card]: emit event on change

### DIFF
--- a/packages/openbridge-webcomponents/src/components/elevated-card-radio/elevated-card-radio.ts
+++ b/packages/openbridge-webcomponents/src/components/elevated-card-radio/elevated-card-radio.ts
@@ -8,6 +8,7 @@ import {
   ObcElevatedCardTag,
 } from '../elevated-card/elevated-card.js';
 import {customElement} from '../../decorator.js';
+import {ObcRadio} from '../radio/radio.js';
 
 /**
  * `<obc-elevated-card-radio>` – A single radio button presented within an elevated card container for visually distinct selection in a group.
@@ -83,6 +84,7 @@ import {customElement} from '../../decorator.js';
  *
  * @slot leading-icon - Contains the radio button input.
  * @slot label - Displays the label text for the radio option.
+ * @fires change - Fired when the radio is changed.
  */
 @customElement('obc-elevated-card-radio')
 export class ObcElevatedCardRadio extends LitElement {
@@ -174,6 +176,7 @@ export class ObcElevatedCardRadio extends LitElement {
           ?checked=${this.checked}
           ?disabled=${this.disabled}
           ?required=${this.required}
+          @change=${this._handleRadioChange}
           slot="leading-icon"
         ></obc-radio>
         <label
@@ -188,6 +191,14 @@ export class ObcElevatedCardRadio extends LitElement {
 
   private _handleCardClick() {
     this.renderRoot.querySelector('input')?.click();
+  }
+
+  private _handleRadioChange(event: Event) {
+    const radio = event.target as ObcRadio;
+    this.checked = radio.checked;
+    this.dispatchEvent(
+      new CustomEvent('change', {detail: {value: radio.value}})
+    );
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small behavioral change limited to a UI component’s event emission; low risk aside from possible duplicate/changed event expectations for consumers.
> 
> **Overview**
> `obc-elevated-card-radio` now listens to the underlying `obc-radio`’s `change` event, syncs its own `checked` state, and re-dispatches a `change` event with `{value}` in `detail` so parents can react to selection changes.
> 
> Adds an explicit `@fires change` annotation and types the event target as `ObcRadio`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cba4214080d14860e9a007cd9aff80018346321c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the elevated card radio component to properly synchronize state and propagate change events from the internal radio control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->