### PR TITLE
Add compact flyout for navigation menu.

### DIFF
--- a/packages/openbridge-webcomponents/src/components/navigation-menu/navigation-menu.stories.ts
+++ b/packages/openbridge-webcomponents/src/components/navigation-menu/navigation-menu.stories.ts
@@ -2,6 +2,7 @@ import type {Meta, StoryObj} from '@storybook/web-components-vite';
 import {
   ObcNavigationMenu,
   ObcNavigationMenuVariant,
+  ObcNavigationMenuFlyoutVariant,
 } from './navigation-menu.js';
 import './navigation-menu.js';
 import '../navigation-item/navigation-item.js';
@@ -25,6 +26,7 @@ const meta: Meta<typeof ObcNavigationMenu> = {
     return html`
       <obc-navigation-menu
         .variant=${args.variant}
+        .flyoutVariant=${args.flyoutVariant}
         .smallScreen=${args.smallScreen}
         style="position: fixed; top: 0; bottom: 0; left: 0;"
       >
@@ -89,12 +91,17 @@ const meta: Meta<typeof ObcNavigationMenu> = {
   },
   args: {
     variant: ObcNavigationMenuVariant.Full,
+    flyoutVariant: ObcNavigationMenuFlyoutVariant.Full,
     smallScreen: false,
   },
   argTypes: {
     variant: {
       control: {type: 'select'},
       options: Object.values(ObcNavigationMenuVariant),
+    },
+    flyoutVariant: {
+      control: {type: 'select'},
+      options: Object.values(ObcNavigationMenuFlyoutVariant),
     },
     smallScreen: {
       control: {type: 'boolean'},
@@ -159,6 +166,13 @@ export const IconOnlyLarge: Story = {
 export const Compact: Story = {
   args: {
     variant: ObcNavigationMenuVariant.Compact,
+  },
+};
+
+export const CompactFlyout: Story = {
+  args: {
+    variant: ObcNavigationMenuVariant.Full,
+    flyoutVariant: ObcNavigationMenuFlyoutVariant.Compact,
   },
 };
 

--- a/packages/openbridge-webcomponents/src/components/navigation-menu/navigation-menu.ts
+++ b/packages/openbridge-webcomponents/src/components/navigation-menu/navigation-menu.ts
@@ -23,6 +23,19 @@ export enum ObcNavigationMenuVariant {
 }
 
 /**
+ * `ObcNavigationMenuFlyoutVariant` – Enumerates the available visual and behavioral variants for the flyout.
+ *
+ * - `Full`: Standard navigation flyout that takes the full height.
+ * - `Compact`: Space-saving menu with reduced padding and layout.
+ *
+ * Use these variants to adapt the flyout menu to different layouts or device sizes.
+ */
+export enum ObcNavigationMenuFlyoutVariant {
+  Full = 'full',
+  Compact = 'compact',
+}
+
+/**
  * `<obc-navigation-menu>` – A flexible, slot-based navigation menu component for organizing primary and secondary navigation items.
  *
  * This component provides a vertical navigation structure supporting groups, flyouts, and footer sections. It adapts to various layouts and device sizes via its `variant` and `smallScreen` properties. Items and groups are provided via slots, allowing for icons, labels, and nested navigation hierarchies.
@@ -119,6 +132,13 @@ export class ObcNavigationMenu extends LitElement {
    */
   @property({type: String}) variant: ObcNavigationMenuVariant =
     ObcNavigationMenuVariant.Full;
+
+  /**
+   * Visual variant of the flyout.
+   * One of `Full` (default) or `Compact`.
+   */
+  @property({type: String}) flyoutVariant: ObcNavigationMenuFlyoutVariant =
+    ObcNavigationMenuFlyoutVariant.Full;
 
   /**
    * When `true`, adapts the layout for small screens (e.g., moves logo into the footer area and adjusts item layout).
@@ -244,7 +264,10 @@ export class ObcNavigationMenu extends LitElement {
 
   protected override updated(_changedProperties: PropertyValues): void {
     super.updated(_changedProperties);
-    if (_changedProperties.has('variant')) {
+    if (
+      _changedProperties.has('variant') ||
+      _changedProperties.has('flyoutVariant')
+    ) {
       this.setupItems();
     }
   }
@@ -278,7 +301,9 @@ export class ObcNavigationMenu extends LitElement {
   }
 
   private setupItems() {
-    const hug = this.variant !== ObcNavigationMenuVariant.Full;
+    const hug =
+      this.variant !== ObcNavigationMenuVariant.Full ||
+      this.flyoutVariant === ObcNavigationMenuFlyoutVariant.Compact;
     this.setHugToGroups(this, hug);
 
     // Set variant to all groups (top-level)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation menu now supports configurable flyout variants: Full and Compact.
  * A new Compact preview variant is available in the component previews to show the compact flyout behavior.
  * The navigation menu exposes a new flyout setting so apps can toggle flyout appearance to suit different layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->