### PR TITLE
feat: navigation-item css part pseudo

### DIFF
--- a/packages/openbridge-webcomponents/src/components/navigation-item/navigation-item.ts
+++ b/packages/openbridge-webcomponents/src/components/navigation-item/navigation-item.ts
@@ -44,6 +44,7 @@ import {customElement} from '../../decorator.js';
  * - Use `group` and `groupSelected` to indicate grouped navigation and selection within groups.
  * - Provide an icon via the `icon` slot for visual context (e.g., `<obi-placeholder slot="icon"></obi-placeholder>).
  * - Use `href` to make the item a link; omit for button-like behavior.
+ * - Use `::part(label)` CSS pseudo-element to style the label.
  *
  * **TODO(designer):** Clarify if there are recommended icon choices or label length constraints for each variant.
  *


### PR DESCRIPTION
Small update to the `ObcNavigationItem` component documentation and template.

* Documentation update: Added a note about using the `::part(label)` CSS pseudo-element to style the label in the component documentation.
* Template update: Added the `part="label"` attribute to the label `<span>` element in the component template, allowing external styles to target the label via the `::part(label)` selector.