### PR TITLE
Fix inverted logic around toggle button vertical option select.

### DIFF
--- a/packages/openbridge-webcomponents/src/components/toggle-button-vertical-option/toggle-button-vertical-option.ts
+++ b/packages/openbridge-webcomponents/src/components/toggle-button-vertical-option/toggle-button-vertical-option.ts
@@ -172,16 +172,14 @@ export class ObcToggleButtonVerticalOption extends LitElement {
 
     // Only fire event if not already selected
     if (!this.selected) {
-      return;
+      this.dispatchEvent(
+        new CustomEvent('selected', {
+          detail: {value: this.value},
+          bubbles: true,
+          composed: true,
+        })
+      );
     }
-
-    this.dispatchEvent(
-      new CustomEvent('selected', {
-        detail: {value: this.value},
-        bubbles: true,
-        composed: true,
-      })
-    );
   }
 
   override render() {


### PR DESCRIPTION
The logic was inverted, so the select only happened when already selected instead of when unselected.