### PR TITLE
refactor(storybook): move indicator stories under 'Indicators' category

### DIFF
--- a/packages/openbridge-webcomponents/.storybook/preview.tsx
+++ b/packages/openbridge-webcomponents/.storybook/preview.tsx
@@ -76,6 +76,7 @@ const preview: Preview = {
           'UI Components',
           'Bars and Graphs',
           'Instruments',
+          'Indicators',
           'Automation',
           'AR',
           'Integration',

--- a/packages/openbridge-webcomponents/src/navigation-instruments/bearing-indicator/bearing-indicator.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/bearing-indicator/bearing-indicator.stories.ts
@@ -3,7 +3,7 @@ import {ObcBearingIndicator} from './bearing-indicator.js';
 import './bearing-indicator.js';
 
 const meta: Meta<typeof ObcBearingIndicator> = {
-  title: 'Instruments/Bearing Indicator',
+  title: 'Indicators/Bearing Indicator',
   tags: ['6.0'],
   component: 'obc-bearing-indicator',
   args: {},

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-indicator/compass-indicator.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-indicator/compass-indicator.stories.ts
@@ -6,7 +6,7 @@ import {
 import './compass-indicator.js';
 
 const meta: Meta<typeof ObcCompassIndicator> = {
-  title: 'Instruments/Compass Indicator',
+  title: 'Indicators/Compass Indicator',
   tags: ['6.0'],
   component: 'obc-compass-indicator',
   args: {

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rot-indicator/rot-indicator.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rot-indicator/rot-indicator.stories.ts
@@ -3,7 +3,7 @@ import {ObcRotIndicator} from './rot-indicator.js';
 import './rot-indicator.js';
 
 const meta: Meta<typeof ObcRotIndicator> = {
-  title: 'Instruments/Rate of Turn Indicator',
+  title: 'Indicators/Rate of Turn Indicator',
   tags: ['6.0'],
   component: 'obc-rot-indicator',
   args: {},

--- a/packages/openbridge-webcomponents/src/navigation-instruments/speed-indicator/speed-indicator.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/speed-indicator/speed-indicator.stories.ts
@@ -3,7 +3,7 @@ import {ObcSpeedIndicator} from './speed-indicator.js';
 import './speed-indicator.js';
 
 const meta: Meta<typeof ObcSpeedIndicator> = {
-  title: 'Instruments/Speed Indicator',
+  title: 'Indicators/Speed Indicator',
   tags: ['6.0'],
   component: 'obc-speed-indicator',
   argTypes: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized navigation-related components into a dedicated "Indicators" category in Storybook.
  * Added "Indicators" to the Storybook story order, placing it after "Instruments" and before "Automation".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->