### PR TITLE
feat: expose POI icon rotation as CSS ::part(icon)

### DIFF
--- a/packages/openbridge-webcomponents/src/ar/building-blocks/poi-button/poi-button.ts
+++ b/packages/openbridge-webcomponents/src/ar/building-blocks/poi-button/poi-button.ts
@@ -266,9 +266,11 @@ export class ObcPoiButton extends LitElement {
         .objectStyle=${ObcPoiObjectStyle.Regular}
         .state=${this.poiObjectState}
         .interactive=${false}
+        exportparts="icon"
       >
         <span
           class="icon"
+          part="icon"
           style="transform: rotate(${this.relativeDirection}deg);"
         >
           <slot></slot>

--- a/packages/openbridge-webcomponents/src/ar/building-blocks/poi/poi.ts
+++ b/packages/openbridge-webcomponents/src/ar/building-blocks/poi/poi.ts
@@ -409,6 +409,7 @@ export class ObcPoi extends LitElement {
         .overlapOpaque=${this.overlapOpaque}
         .type=${this.buttonType}
         .data=${this.data}
+        exportparts="icon"
       >
         <slot></slot>
         <slot name="header" slot="header"></slot>

--- a/packages/openbridge-webcomponents/src/ar/poi-data/poi-data.ts
+++ b/packages/openbridge-webcomponents/src/ar/poi-data/poi-data.ts
@@ -471,6 +471,7 @@ export class ObcPoiData extends LitElement {
         .targetOffsetX=${this.targetOffsetX}
         .boxWidth=${this.boxWidth}
         .boxHeight=${this.boxHeight}
+        exportparts="icon"
       >
         ${this.hasHeader
           ? html`<slot name="header" slot="header"></slot>`


### PR DESCRIPTION
Add part="icon" to the icon span in obc-poi-button and forward it via exportparts="icon" through obc-poi-object, obc-poi-button, obc-poi, and obc-poi-data. This lets consumers style icon rotation transitions from outside the shadow DOM, e.g.:

  obc-poi-data::part(icon) { transition: transform 0.4s ease-out; }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced icon styling capabilities in POI components. Users can now customize the appearance of icons within Points of Interest elements using CSS styling from outside the component, providing greater design flexibility and customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->