### PR TITLE
feat: add build step for openbridge-webcomponents in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
         run: |
           npm publish  --registry=https://npm.pkg.github.com/${{ github.repository_owner }} --access restricted
 
+      - name: Build and generate wrappers
+        working-directory: ./packages/openbridge-webcomponents
+        run: |
+          npm run build:full
+
       - name: Publish react wrapper to GitHub Packages
         working-directory: ./packages/openbridge-webcomponents-react
         env:


### PR DESCRIPTION
@tibnor i am not sure why it failed on the `main` branch. The build passed in the PR. However this might fix it...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow to include a build step for wrapper generation, ensuring components are properly prepared during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->