### PR TITLE
feat(table): add sort animation and expose ::part(body)

### DIFF
--- a/packages/openbridge-webcomponents/src/components/table/table.ts
+++ b/packages/openbridge-webcomponents/src/components/table/table.ts
@@ -528,7 +528,11 @@ export class ObcTable extends LitElement {
       });
     }
 
-    if (changedProperties.has('data')) {
+    if (
+      changedProperties.has('data') ||
+      changedProperties.has('_sortByColumnIdx') ||
+      changedProperties.has('_sortDirection')
+    ) {
       if (this._hasRenderedRows) {
         this._updatePositions();
       } else {
@@ -558,7 +562,11 @@ export class ObcTable extends LitElement {
       }
     }
 
-    if (changedProperties.has('data')) {
+    if (
+      changedProperties.has('data') ||
+      changedProperties.has('_sortByColumnIdx') ||
+      changedProperties.has('_sortDirection')
+    ) {
       if (this._hasRenderedRows) {
         this._animateRowChanges();
       }
@@ -682,6 +690,7 @@ export class ObcTable extends LitElement {
           : nothing}
         <div
           class="grid-body"
+          part="body"
           style="grid-template-rows: repeat(${this.sortedData
             .length}, min-content)"
         >


### PR DESCRIPTION
- Extend the existing FLIP row animation to trigger when sort state changes (_sortByColumnIdx, _sortDirection), so rows animate smoothly when a column header is clicked instead of snapping into place.
- Add part="body" to the .grid-body element, allowing consumers to override styles like scrollbar-gutter via obc-table::part(body).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced table sorting behavior by ensuring row animations and position updates are properly triggered and displayed whenever the sort order or selected column changes.

* **New Features**
  * Exposed the table body element for advanced styling and test automation customization, enabling developers to better integrate the component with their tools, systems and testing frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->