### PR TITLE
fix(devcontainer): update postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,31 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-	"name": "Node.js & TypeScript",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-24.04",
-	"features": {
-		"ghcr.io/devcontainers/features/node:1": {
-			"version": "22"
-		},
-		"ghcr.io/devcontainers/features/git:1": {}
-	},
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install && npm run build:lib && cd packages/openbridge-webcomponents && npx playwright install --with-deps",
-	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"Vue.volar",
-				"GitHub.copilot",
-				"jackolope.lit-analyzer-plugin"
-			]
-		}
-	}
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  "name": "Node.js & TypeScript",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "npm install && cd packages/openbridge-webcomponents && npm run build:full && cd ../.. && npm run build:lib && cd packages/openbridge-webcomponents && npx playwright install --with-deps",
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Vue.volar",
+        "GitHub.copilot",
+        "jackolope.lit-analyzer-plugin"
+      ]
+    }
+  }
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }


### PR DESCRIPTION
@tibnor i have noticed that the old `"postCreateCommand": "npm install && npm run build:lib && cd packages/openbridge-webcomponents && npx playwright install --with-deps"` wasn't working, i guess because of the changes made to https://github.com/Ocean-Industries-Concept-Lab/openbridge-webcomponents-jip/blob/main/packages/openbridge-webcomponents/package.json#L11. This PR fixes it (i have tested by recreating the devcontainer from scratch), however i am not 100% confident this is the way it should be. Please take a look.

Probably the automated code review commands are correct, keeping this as a draft...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration to enhance the setup experience. The post-creation command now includes npm installation, web components compilation, library build, and Playwright dependency installation in a single automated sequence. This streamlines the environment initialization process for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->