### PR TITLE
fix[chat-message]: use correct color for other

### DIFF
--- a/packages/openbridge-webcomponents/src/components/chat-message/chat-message.css
+++ b/packages/openbridge-webcomponents/src/components/chat-message/chat-message.css
@@ -49,7 +49,7 @@
 
   .other & {
     background-color: var(--amplified-enabled-background-color);
-    color: var(--base-blue-600);
+    color: var(--on-amplified-active-color);
     border-top-left-radius: 0;
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single CSS token change affecting only chat message styling; no logic or data-flow impact.
> 
> **Overview**
> Updates `chat-message.css` so messages from *other* users use `--on-amplified-active-color` instead of a hard-coded `--base-blue-600`, aligning text contrast with the amplified background theme token.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c42c2f0f40c454a45ac0c49ee47d5d3a7e351cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chat message color styling to improve visual consistency and theme alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->