### PR TITLE
build: retry storybook test on ci

### DIFF
--- a/packages/openbridge-webcomponents/vitest.config.ts
+++ b/packages/openbridge-webcomponents/vitest.config.ts
@@ -11,7 +11,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
-    // Use `workspace` field in Vitest < 3.2
+    retry: process.env.CI ? 2 : 0,
     projects: [
       {
         extends: true,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Vitest configuration to retry flaky Storybook/browser tests on CI, with no production code or data/auth logic changes.
> 
> **Overview**
> Adds a CI-only Vitest retry policy (`retry: process.env.CI ? 2 : 0`) for the `openbridge-webcomponents` Storybook test project to reduce flaky failures in automated runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cb547a6eba71f8697b785fcb3ed6782f9a93f44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to improve reliability in continuous integration environments by enabling automatic retry logic for failed tests when running in CI pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->