### PR TITLE
feat(rot): add configurable rotAtZeroDeadband property

### DIFF
--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-flat/compass-flat.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-flat/compass-flat.ts
@@ -8,6 +8,7 @@ import {Priority} from '../types.js';
 import {
   RotType,
   LINEAR_DOT_ANGLE_SPACING,
+  ROT_ZERO_DEADBAND_DEG,
 } from '../rate-of-turn/rot-renderer.js';
 
 export {RotType};
@@ -86,6 +87,7 @@ export class ObcCompassFlat extends LitElement {
   @property({type: Number}) rotMaxValue: number = 10;
   @property({type: Number}) rotArcExtent: number = 60;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
+  @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
 
   @state() private containerWidth = 0;
   @state() private maxContainerWidth = 0;
@@ -310,6 +312,7 @@ export class ObcCompassFlat extends LitElement {
           .rotationsPerMinute=${this.rotationsPerMinute}
           .rotPriority=${this.priorityFor(CompassFlatPriorityElement.rot)}
           .rotPortStarboard=${this.rotPortStarboard}
+          .rotAtZeroDeadband=${this.rotAtZeroDeadband * translationScale}
         ></obc-watch-flat>
         <svg viewBox=${viewBox} xmlns="http://www.w3.org/2000/svg">
           ${this.HDGSvg}${this.COGSvg(translation)}

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-sector/compass-sector.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-sector/compass-sector.ts
@@ -18,6 +18,7 @@ import {
   computeZoomToFitArcFrame,
   type ZoomToFitArcFrame,
 } from '../../svghelpers/arc-frame.js';
+import {ROT_ZERO_DEADBAND_DEG} from '../rate-of-turn/rot-renderer.js';
 import {customElement} from '../../decorator.js';
 import {InstrumentState, Priority} from '../types.js';
 export {RotType, RotPosition};
@@ -117,6 +118,7 @@ export class ObcCompassSector extends LitElement {
   @property({type: Number}) rotationsPerMinute: number = 1;
   @property({type: Number}) rotMaxValue: number = 10;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
+  @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
 
   @property({type: String}) state: InstrumentState = InstrumentState.active;
   @property({type: String}) priority: Priority = Priority.regular;
@@ -411,6 +413,7 @@ export class ObcCompassSector extends LitElement {
           .rotEndAngle=${this._rotEndAngle}
           .rotPriority=${this.priorityFor(CompassSectorPriorityElement.rot)}
           .rotPortStarboard=${this.rotPortStarboard}
+          .rotAtZeroDeadband=${this.rotAtZeroDeadband}
           .rotationsPerMinute=${this.rotationsPerMinute}
         >
         </obc-watch>

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.ts
@@ -13,6 +13,7 @@ import {
   RotPosition,
 } from '../watch/watch.js';
 import {SetpointBundle} from '../../svghelpers/setpoint-bundle.js';
+import {ROT_ZERO_DEADBAND_DEG} from '../rate-of-turn/rot-renderer.js';
 import {customElement} from '../../decorator.js';
 import {InstrumentState, Priority} from '../types.js';
 export {RotType};
@@ -137,6 +138,7 @@ export class ObcCompass extends LitElement {
   @property({type: Number}) rotMaxValue: number = 10;
   @property({type: Number}) rotArcExtent: number = 60;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
+  @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
   @property({type: String}) direction: CompassDirection =
     CompassDirection.NorthUp;
   @property({type: String}) state: InstrumentState = InstrumentState.active;
@@ -282,6 +284,7 @@ export class ObcCompass extends LitElement {
           (this.getRotation() ?? 0)}
           .rotPriority=${this.priorityFor(CompassPriorityElement.rot)}
           .rotPortStarboard=${this.rotPortStarboard}
+          .rotAtZeroDeadband=${this.rotAtZeroDeadband}
           .rotationsPerMinute=${this.rotationsPerMinute}
         >
         </obc-watch>

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rate-of-turn/rate-of-turn.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rate-of-turn/rate-of-turn.ts
@@ -2,6 +2,7 @@ import {LitElement, css, html} from 'lit';
 import {property} from 'lit/decorators.js';
 import '../watch/watch.js';
 import {WatchCircleType, RotType, RotPosition} from '../watch/watch.js';
+import {ROT_ZERO_DEADBAND_DEG} from './rot-renderer.js';
 import {customElement} from '../../decorator.js';
 import {Priority} from '../types.js';
 
@@ -49,6 +50,7 @@ export class ObcRateOfTurn extends LitElement {
   @property({type: String}) watchCircleType: WatchCircleType =
     WatchCircleType.single;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
+  @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
 
   static override styles = css`
     * {
@@ -81,6 +83,7 @@ export class ObcRateOfTurn extends LitElement {
         .rotEndAngle=${this.barEndAngle}
         .rotationsPerMinute=${this.rotationsPerMinute}
         .rotPortStarboard=${this.rotPortStarboard}
+        .rotAtZeroDeadband=${this.rotAtZeroDeadband}
       ></obc-watch>
     </div>`;
   }

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch-flat/watch-flat.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch-flat/watch-flat.ts
@@ -65,6 +65,7 @@ export class ObcWatchFlat extends LitElement {
   @property({type: Number}) rotDotSpacing: number = 0;
   @property({type: String}) rotPriority: Priority = Priority.regular;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
+  @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_PX;
 
   @property({type: Number})
   set rotationsPerMinute(value: number) {
@@ -250,13 +251,12 @@ export class ObcWatchFlat extends LitElement {
 
     if (this.rotType === RotType.bar) {
       const span = Math.abs(this.rotEndX - this.rotStartX);
+      const zeroDb = Number.isFinite(this.rotAtZeroDeadband)
+        ? this.rotAtZeroDeadband
+        : ROT_ZERO_DEADBAND_PX;
 
-      if (span < ROT_ZERO_DEADBAND_PX) {
+      if (span < Math.max(zeroDb, BAR_HALF_THICKNESS)) {
         return renderLinearRotZeroPill(barBgColor, this.rotStartX, trackY);
-      }
-
-      if (span < BAR_HALF_THICKNESS) {
-        return nothing;
       }
 
       return svg`

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
@@ -243,6 +243,7 @@ export class ObcWatch extends LitElement {
   @property({type: Number}) rotEndAngle: number = 0;
   @property({type: String}) rotPriority: Priority | undefined;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
+  @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
   @property({type: Number})
   set rotationsPerMinute(value: number) {
     this._rotationsPerMinute = value;
@@ -843,18 +844,17 @@ export class ObcWatch extends LitElement {
         this.rotEndAngle
       );
       const threshold = rotBarThresholdAngle(this.rotPosition, rOff);
+      const zeroDb = Number.isFinite(this.rotAtZeroDeadband)
+        ? this.rotAtZeroDeadband
+        : ROT_ZERO_DEADBAND_DEG;
 
-      if (angularDelta < ROT_ZERO_DEADBAND_DEG) {
+      if (angularDelta < Math.max(zeroDb, threshold)) {
         return renderRotZeroPill(
           barBgColor,
           this.rotStartAngle,
           this.rotPosition,
           rOff
         );
-      }
-
-      if (angularDelta < threshold) {
-        return nothing;
       }
 
       return svg`


### PR DESCRIPTION
Replace hardcoded `ROT_ZERO_DEADBAND_DEG`/`PX` thresholds with a configurable `rotAtZeroDeadband` property on **watch**, **watch-flat**, and all consumer instruments (**compass**, **compass-sector**, **compass-flat**, **rate-of-turn**). The zero pill now renders continuously until the bar is large enough to display, closing the visual gap between the two thresholds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "ROT zero deadband" setting across compass (flat, sector, main), rate-of-turn, and watch/watch-flat instruments. The zero-threshold for the ROT indicator and bar rendering is now exposed and applied (including scaling in flat views), allowing the visual zero-pill/deadband behavior to be adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->