### PR TITLE
build: allow all files in wrappers if no file is empty in package.json

### DIFF
--- a/packages/openbridge-webcomponents/fix-generated.cjs
+++ b/packages/openbridge-webcomponents/fix-generated.cjs
@@ -31,10 +31,7 @@ function fixPackageJson(packageName, directory) {
     access: 'public',
   };
 
-  if (!packageJson.files) {
-    packageJson.files = [];
-  }
-  if (!packageJson.files.includes('README.md')) {
+  if (packageJson.files && !packageJson.files.includes('README.md')) {
     packageJson.files.push('README.md');
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package metadata handling during the generation process to prevent unnecessary overrides of existing file configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->