### PR TITLE
fix(ci): npm ci may not work for wrappers as package.lock doesn't exist yet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,6 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         run: |
-          npm version ${{ env.VERSION }} --no-git-tag-version --workspaces
           npm version ${{ env.VERSION }} --no-git-tag-version
 
       - name: Build and generate wrappers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         run: npm run build:full
 
       - name: Install wrapper dependencies
-        run: npm ci
+        run: npm install
 
       - name: Publish core to NPM
         working-directory: ./packages/openbridge-webcomponents


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to refine package versioning and dependency installation processes for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->