### PR TITLE
fix(automation-tank): center host element on crosshair anchor point

### DIFF
--- a/packages/openbridge-webcomponents/src/automation/automation-tank/automation-tank.css
+++ b/packages/openbridge-webcomponents/src/automation/automation-tank/automation-tank.css
@@ -2,6 +2,12 @@
   box-sizing: border-box;
 }
 
+:host {
+  display: block;
+  width: fit-content;
+  translate: -50% -50%;
+}
+
 .trend-icon {
   display: block;
   width: 24px;
@@ -12,10 +18,6 @@
   display: flex;
   width: fit-content;
   flex-direction: column;
-  /* This is a hack to make the badge appear above the content */
-  position: relative;
-  top: -20px;
-  transform: translateX(-50%);
 }
 
 .badges {


### PR DESCRIPTION
## Fix: automation-tank centering on crosshair anchor point

The centering transform (`translateX(-50%)`) and vertical offset (`position: relative; top: -20px`) were applied to `.outer` inside the shadow DOM instead of on `:host`. This shifted the visual content without moving the host element's box, causing the browser's element overlay to appear off-center from the rendered component.

Moved the centering to `:host` using the individual `translate` property (`translate: -50% -50%`) instead of `transform: translate(...)`, keeping `transform` free for consumers to apply their own rotate/scale. Replaced the partial `translateX(-50%) + top: -20px` hack with proper two-axis centering on the crosshair anchor point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved component positioning and layout for more consistent rendering.
  * Fixed badge/alignment behavior by consolidating layout responsibilities, reducing visual offsets.
  * Ensures components size and center more reliably across contexts for better visual stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->