### PR TITLE
docs(automation): document P&ID anchor point model in instructions

### DIFF
--- a/.github/instructions/automation-components.instructions.md
+++ b/.github/instructions/automation-components.instructions.md
@@ -90,3 +90,19 @@ Analog valves render inline dynamic SVG (not icon swapping):
 ## Badge Positioning
 
 Badges (`badgeAuto`, `badgeCommandLocked`, `badgeDuty`, `badgeAlertOff`) render in corner slots. Badge spacer logic is computed based on readout position and which badges are present. Do not hard-code spacer visibility.
+
+## P&ID Anchor Point Model
+
+All automation components are placed on a P&ID canvas using `position: absolute; left: Xpx; top: Ypx`. This places the element's **top-left corner** at the given coordinate. Each component then uses internal CSS to shift itself so that a meaningful **anchor point** aligns with that coordinate — the point where pipes connect.
+
+The Storybook `crossDecorator` simulates this layout: it wraps the component in a `position: relative` container and places children at `position: absolute; top: 50%; left: 50%`, with optional crosshair lines to visualize the anchor.
+
+Different components have different anchor points:
+
+| Component type | Anchor point | Internal CSS technique |
+|----------------|-------------|------------------------|
+| Valve / pump / motor | Center of icon | 0×0 `.point-wrapper` at anchor + negative offset by half touch-target size + `translateX(-50%)` for top/bottom positioning or `translateY(-50%)` for left/right positioning |
+| Tank | Top-center of tank body | `translateX(-50%)` on `.outer` + `top: -20px` to skip badge area |
+| Line segments | Left/top edge of line | SVG typically drawn around the 24px grid center (for example x=12 or y=12) + visual offset by about half the grid to align to the host edge, with minor `±0.5px` stroke/viewBox adjustments and direction-specific shifts where needed |
+
+**Do not change the centering transforms** on automation components without understanding the anchor point intent. The browser's element overlay (host box) will often appear offset from the visual content — this is intentional because the host box starts at the placement coordinate while the visual content is shifted to align the anchor.


### PR DESCRIPTION
Context: This started in https://github.com/Ocean-Industries-Concept-Lab/openbridge-webcomponents/issues/791 but later @tibnor explained that it was the intended approach. That’s why I declined that PR and created this documentation as a result of taking a deeper look into the automation components’ CSS and trying to understand the layout logic. I thought we could add a new section to the AI instructions, just so it’s documented somewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added P&ID anchor point positioning model describing how automation components are placed on the canvas and how internal alignment ensures defined pipe connection anchor points match host coordinates. Includes guidance and examples for valves, pumps, motors, tanks, and line segments, notes on preview simulation of anchor placement, and a warning against unintended changes to centering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->