### PR TITLE
fix(bundle): remove spec file from bundle 

### DIFF
--- a/packages/openbridge-webcomponents/script/generate-bundle-entry.ts
+++ b/packages/openbridge-webcomponents/script/generate-bundle-entry.ts
@@ -15,7 +15,7 @@ function findComponentFiles(
     return components;
   }
 
-  const items = globSync(`${fullPath}/**/*.ts`, {ignore: ['**/*.stories.ts']});
+  const items = globSync(`${fullPath}/**/*.ts`, {ignore: ['**/*.stories.ts', '**/*.spec.ts']});
   const rootPath = path.join(process.cwd());
 
   for (const item of items) {

--- a/packages/openbridge-webcomponents/script/generate-bundle-entry.ts
+++ b/packages/openbridge-webcomponents/script/generate-bundle-entry.ts
@@ -15,7 +15,9 @@ function findComponentFiles(
     return components;
   }
 
-  const items = globSync(`${fullPath}/**/*.ts`, {ignore: ['**/*.stories.ts', '**/*.spec.ts']});
+  const items = globSync(`${fullPath}/**/*.ts`, {
+    ignore: ['**/*.stories.ts', '**/*.spec.ts'],
+  });
   const rootPath = path.join(process.cwd());
 
   for (const item of items) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bundle generation now excludes test spec files (e.g., TypeScript .spec files) in addition to story files, preventing test code from being included in generated bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->