### PR TITLE
fix: improve keyboard accessibility for menu and split buttons

### DIFF
--- a/packages/openbridge-webcomponents/src/components/checkbox-item/checkbox-item.ts
+++ b/packages/openbridge-webcomponents/src/components/checkbox-item/checkbox-item.ts
@@ -140,6 +140,10 @@ export class ObcCheckboxItem extends LitElement {
     );
   }
 
+  public override focus(options?: FocusOptions): void {
+    this.checkboxElement?.focus(options);
+  }
+
   override render() {
     const isDisabled =
       this.disabled || this.state === ObcCheckboxItemState.disabled;

--- a/packages/openbridge-webcomponents/src/components/context-menu-input/context-menu-input.ts
+++ b/packages/openbridge-webcomponents/src/components/context-menu-input/context-menu-input.ts
@@ -147,7 +147,7 @@ export enum ContextMenuType {
  * ## Properties
  *
  * - `type` (`ContextMenuType`): Sets the menu variant. Defaults to `'regular'`.
- * - `options` (ContextMenuOption[]): Array of menu options. Each option can have `value`, `label`, optional `icon`, `level` (for nesting), and `children` (for flyout/nested).
+ * - `options` (`ContextMenuOption[]`): Array of menu options. Each option can have `value`, `label`, optional `icon`, `level` (for nesting), and `children` (for flyout/nested).
  * - `selectedValues` (string[]): Array of currently selected option values.
  * - `hasTitleBar` (boolean): If true, displays a title bar with close button.
  * - `title` (string): Text for the title bar (shown if `hasTitleBar` is true).
@@ -160,9 +160,9 @@ export enum ContextMenuType {
  * ## Events
  *
  * - `change` – Fired when the selection changes.
- *   Detail: `{ selectedValues: string[], selectedOptions: ContextMenuOption[] }`
+ *   Detail includes the selected values array and the selected option objects.
  * - `item-click` – Fired when a menu item is clicked (even if not changing selection).
- *   Detail: `{ value: string, option: ContextMenuOption }`
+ *   Detail includes the clicked value and its option object.
  * - `close` – Fired when the close button in the title bar is clicked.
  *
  * ## Best Practices and Constraints
@@ -202,9 +202,9 @@ export enum ContextMenuType {
  * In this example, a flyout menu is shown with a title bar, group icons, and a selected child option.
  *
  * @slot - Optionally used for custom icons in options (e.g., `<obi-placeholder slot="icon"></obi-placeholder>`)
- * @fires change {CustomEvent<{selectedValues: string[], selectedOptions: ContextMenuOption[]}>} When the selection changes.
- * @fires item-click {CustomEvent<{value: string, option: ContextMenuOption}>} When a menu item is clicked.
- * @fires close {CustomEvent<void>} When the close button is clicked.
+ * @fires change {ObcContextMenuInputChangeEvent} Fired when the selection changes.
+ * @fires item-click {ObcContextMenuInputItemClickEvent} Fired when a menu item is clicked.
+ * @fires close {CustomEvent<void>} Fired when the close button is clicked.
  */
 @customElement('obc-context-menu-input')
 export class ObcContextMenuInput extends LitElement {
@@ -279,6 +279,122 @@ export class ObcContextMenuInput extends LitElement {
    * When enabled, only one option can be selected in each group or column.
    */
   @property({type: Boolean, reflect: true}) selectPerGroup?: boolean;
+
+  private getMenuItems(): HTMLElement[] {
+    return Array.from(
+      this.renderRoot.querySelectorAll<HTMLElement>('[data-menu-item="true"]')
+    ).filter((item) => item.getClientRects().length > 0);
+  }
+
+  private getFocusedMenuItemIndex(): number {
+    const activeElement =
+      this.renderRoot instanceof ShadowRoot
+        ? this.renderRoot.activeElement
+        : document.activeElement;
+
+    if (!(activeElement instanceof HTMLElement)) {
+      return -1;
+    }
+
+    const items = this.getMenuItems();
+    let closestIndex = -1;
+    let closestDistance = Number.POSITIVE_INFINITY;
+
+    items.forEach((item, index) => {
+      if (item !== activeElement && !item.contains(activeElement)) {
+        return;
+      }
+
+      let distance = 0;
+      let currentElement: HTMLElement | null = activeElement;
+      while (currentElement !== null && currentElement !== item) {
+        currentElement = currentElement.parentElement;
+        distance += 1;
+      }
+
+      if (currentElement === item && distance < closestDistance) {
+        closestDistance = distance;
+        closestIndex = index;
+      }
+    });
+
+    return closestIndex;
+  }
+
+  private focusMenuItem(index: number) {
+    const items = this.getMenuItems();
+    if (items.length === 0) return;
+
+    const normalizedIndex = Math.max(0, Math.min(index, items.length - 1));
+    items[normalizedIndex].focus();
+    items[normalizedIndex].scrollIntoView({block: 'nearest'});
+  }
+
+  public focusFirstItem() {
+    this.focusMenuItem(0);
+  }
+
+  public focusLastItem() {
+    const items = this.getMenuItems();
+    if (items.length === 0) return;
+
+    this.focusMenuItem(items.length - 1);
+  }
+
+  public focusSelectedItem() {
+    const items = this.getMenuItems();
+    if (items.length === 0) return;
+
+    const selectedItem = this.selectedValues
+      .map((value) =>
+        items.find((item) => item.getAttribute('data-menu-value') === value)
+      )
+      .find((item): item is HTMLElement => item !== undefined);
+
+    if (selectedItem !== undefined) {
+      selectedItem.focus();
+      selectedItem.scrollIntoView({block: 'nearest'});
+      return;
+    }
+
+    this.focusFirstItem();
+  }
+
+  private handleKeydown(event: KeyboardEvent) {
+    const items = this.getMenuItems();
+    if (items.length === 0) return;
+
+    const currentIndex = this.getFocusedMenuItemIndex();
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.focusMenuItem(
+          currentIndex < 0 ? 0 : Math.min(currentIndex + 1, items.length - 1)
+        );
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.focusMenuItem(
+          currentIndex < 0 ? items.length - 1 : Math.max(currentIndex - 1, 0)
+        );
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.focusFirstItem();
+        break;
+      case 'End':
+        event.preventDefault();
+        this.focusLastItem();
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.dispatchEvent(new CustomEvent('close'));
+        break;
+      default:
+        break;
+    }
+  }
 
   private get isMultiSelect(): boolean {
     if (this.multiSelect !== undefined) return this.multiSelect;
@@ -489,6 +605,8 @@ export class ObcContextMenuInput extends LitElement {
         style=${indent ? `padding-left:${indent}px` : ''}
       >
         <obc-checkbox-item
+          data-menu-item="true"
+          data-menu-value=${o.value}
           .label=${o.label}
           .status=${isSelected ? 'checked' : 'unchecked'}
           @change=${(e: Event) => this.handleCheckboxChange(o, e)}
@@ -505,6 +623,8 @@ export class ObcContextMenuInput extends LitElement {
       style=${indent ? `padding-left:${indent}px` : ''}
     >
       <obc-navigation-item
+        data-menu-item="true"
+        data-menu-value=${o.value}
         .label=${o.label}
         .checked=${isSelected}
         .variant=${ObcNavigationMenuVariant.Full}
@@ -525,6 +645,8 @@ export class ObcContextMenuInput extends LitElement {
         const isSelected = this.isOptionSelected(c.value);
         return html`<div class="menu-item checkbox-item-wrapper">
           <obc-checkbox-item
+            data-menu-item="true"
+            data-menu-value=${c.value}
             .label=${c.label}
             .status=${isSelected ? 'checked' : 'unchecked'}
             @change=${(e: Event) => this.handleCheckboxChange(c, e)}
@@ -535,6 +657,8 @@ export class ObcContextMenuInput extends LitElement {
     return children.map((c) => {
       const isSelected = this.isOptionSelected(c.value);
       return html`<obc-navigation-item
+        data-menu-item="true"
+        data-menu-value=${c.value}
         .label=${c.label}
         .checked=${isSelected}
         .variant=${ObcNavigationMenuVariant.Full}
@@ -566,6 +690,8 @@ export class ObcContextMenuInput extends LitElement {
       const isSelected = this.isOptionSelected(o.value);
       if (o.children?.length) {
         return html`<obc-navigation-item-group
+          data-menu-item="true"
+          data-menu-value=${o.value}
           .label=${o.label}
           .checked=${isSelected}
           .variant=${ObcNavigationMenuVariant.Full}
@@ -601,6 +727,8 @@ export class ObcContextMenuInput extends LitElement {
           const isSelected = this.isOptionSelected(o.value);
           return html`<div class="menu-item checkbox-item-wrapper">
             <obc-checkbox-item
+              data-menu-item="true"
+              data-menu-value=${o.value}
               .label=${o.label}
               .status=${isSelected ? 'checked' : 'unchecked'}
               @change=${(e: Event) => this.handleCheckboxChange(o, e)}
@@ -741,8 +869,10 @@ export class ObcContextMenuInput extends LitElement {
         [`type-${this.type}`]: true,
         'has-title': this.hasTitleBar,
       })}
+      tabindex="-1"
       role="menu"
       aria-label=${this.hasTitleBar ? this.title : 'Context menu'}
+      @keydown=${this.handleKeydown}
     >
       ${this.renderTitleBar()}
       <div class="menu-content">${this.renderMenuContent()}</div>

--- a/packages/openbridge-webcomponents/src/components/menu-button/menu-button.ts
+++ b/packages/openbridge-webcomponents/src/components/menu-button/menu-button.ts
@@ -11,6 +11,7 @@ import {
   ContextMenuOption,
   ColumnGroup,
 } from '../context-menu-input/context-menu-input.js';
+import type {ObcContextMenuInput} from '../context-menu-input/context-menu-input.js';
 
 export type ObcSplitButtonChangeEvent = CustomEvent<{
   selectedValues: string[];
@@ -121,8 +122,8 @@ export type ObcMenuButtonItemClickEvent = CustomEvent<{
  * In this example, the button displays an icon and label, and opens a menu with two options (one with an icon).
  *
  * @slot icon - Icon displayed at the start of the button when `hasIcon` is true.
- * @fires change {CustomEvent<{selectedValues: string[], selectedOptions: Array<ContextMenuOption>}>} Fired when the menu selection changes.
- * @fires item-click {CustomEvent<{value: string, option: ContextMenuOption}>} Fired when a menu item is clicked.
+ * @fires change {ObcSplitButtonChangeEvent} Fired when the menu selection changes.
+ * @fires item-click {ObcMenuButtonItemClickEvent} Fired when a menu item is clicked.
  * @fires open {CustomEvent<void>} Fired when the menu is opened.
  * @fires close {CustomEvent<void>} Fired when the menu is closed.
  */
@@ -227,7 +228,13 @@ export class ObcMenuButton extends LitElement {
 
   @state() private isOpen = false;
 
-  @query('.positioned-menu') private menu?: HTMLElement;
+  private restoreFocusOnClose = false;
+
+  private menuFocusStrategy: 'first' | 'selected' | 'last' = 'selected';
+
+  @query('.positioned-menu') private menu?: HTMLElement & ObcContextMenuInput;
+
+  @query('button.wrapper') private triggerButton?: HTMLButtonElement;
 
   private get effectiveMultiSelect(): boolean {
     if (this.multiSelect !== undefined) return this.multiSelect;
@@ -256,6 +263,7 @@ export class ObcMenuButton extends LitElement {
   private handlePopoverToggle = (e: ToggleEvent) => {
     this.isOpen = e.newState === 'open';
     if (e.newState === 'open') {
+      void this.focusMenuAfterOpen();
       /**
        * Fired when the menu is opened.
        * @event open
@@ -264,6 +272,10 @@ export class ObcMenuButton extends LitElement {
       this.dispatchEvent(new CustomEvent('open'));
     }
     if (e.newState === 'closed') {
+      if (this.restoreFocusOnClose) {
+        this.restoreFocusOnClose = false;
+        this.triggerButton?.focus();
+      }
       /**
        * Fired when the menu is closed.
        * @event close
@@ -272,6 +284,50 @@ export class ObcMenuButton extends LitElement {
       this.dispatchEvent(new CustomEvent('close'));
     }
   };
+
+  private async focusMenuAfterOpen() {
+    await this.updateComplete;
+    if (this.menuFocusStrategy === 'last') {
+      this.menu?.focusLastItem();
+    } else if (this.menuFocusStrategy === 'first') {
+      this.menu?.focusFirstItem();
+    } else {
+      this.menu?.focusSelectedItem();
+    }
+    this.menuFocusStrategy = 'selected';
+  }
+
+  private openMenu(focusStrategy: 'first' | 'selected' | 'last' = 'selected') {
+    if (this.disabled) return;
+
+    this.menuFocusStrategy = focusStrategy;
+    this.menu?.showPopover();
+  }
+
+  private handleTriggerKeydown(event: KeyboardEvent) {
+    if (this.disabled) return;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.openMenu('first');
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.openMenu('last');
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.openMenu('first');
+        break;
+      case 'End':
+        event.preventDefault();
+        this.openMenu('last');
+        break;
+      default:
+        break;
+    }
+  }
 
   private handleMenuChange(
     e: CustomEvent<{
@@ -318,6 +374,7 @@ export class ObcMenuButton extends LitElement {
 
   private handleMenuClose() {
     if (this.menu === undefined) return;
+    this.restoreFocusOnClose = true;
     this.menu.hidePopover();
   }
 
@@ -350,6 +407,7 @@ export class ObcMenuButton extends LitElement {
         popovertarget="menu-popover"
         aria-expanded=${this.isOpen}
         aria-haspopup="menu"
+        @keydown=${this.handleTriggerKeydown}
       >
         <div class="visible-wrapper">
           <div class="content-container">

--- a/packages/openbridge-webcomponents/src/components/navigation-item-group/navigation-item-group.ts
+++ b/packages/openbridge-webcomponents/src/components/navigation-item-group/navigation-item-group.ts
@@ -1,5 +1,5 @@
 import {LitElement, html, nothing, unsafeCSS} from 'lit';
-import {property, state} from 'lit/decorators.js';
+import {property, query, state} from 'lit/decorators.js';
 import compentStyle from './navigation-item-group.css?inline';
 import {ObcNavigationMenuVariant} from '../navigation-menu/navigation-menu.js';
 import {classMap} from 'lit/directives/class-map.js';
@@ -92,6 +92,8 @@ export class ObcNavigationItemGroup extends LitElement {
 
   @state() private openContainer = false;
 
+  @query('obc-navigation-item') private groupItem?: HTMLElement;
+
   private onClickGroup() {
     if (this.openContainer) {
       this.close();
@@ -114,6 +116,10 @@ export class ObcNavigationItemGroup extends LitElement {
     this.querySelectorAll('obc-navigation-item-group').forEach((item) => {
       item.close();
     });
+  }
+
+  public override focus(options?: FocusOptions): void {
+    this.groupItem?.focus(options);
   }
 
   override render() {

--- a/packages/openbridge-webcomponents/src/components/navigation-item/navigation-item.ts
+++ b/packages/openbridge-webcomponents/src/components/navigation-item/navigation-item.ts
@@ -1,11 +1,16 @@
 import {LitElement, html, nothing, unsafeCSS} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property, query} from 'lit/decorators.js';
 import compentStyle from './navigation-item.css?inline';
 import {classMap} from 'lit/directives/class-map.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import '../../icons/icon-arrow-flyout-google.js';
 import {ObcNavigationMenuVariant} from '../navigation-menu/navigation-menu.js';
 import {customElement} from '../../decorator.js';
+
+enum NavigationItemRole {
+  Button = 'button',
+  MenuItem = 'menuitem',
+}
 
 /**
  * `<obc-navigation-item>` – A navigation menu item component for use in navigation bars, side menus, or toolbars.
@@ -137,12 +142,49 @@ export class ObcNavigationItem extends LitElement {
 
   @property({type: Boolean}) hasTrailingIcon = false;
 
+  @query('a') private anchorElement?: HTMLAnchorElement;
+
   /**
    * Fired when the navigation item is clicked (either as a link or button).
    * @fires click {CustomEvent<void>}
    */
   onClick() {
     dispatchEvent(new CustomEvent('click'));
+  }
+
+  private handleKeydown(event: KeyboardEvent) {
+    const isMenuItem =
+      this.getAttribute('role') === NavigationItemRole.MenuItem;
+    if (this.href !== undefined && !isMenuItem) return;
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+
+    event.preventDefault();
+    this.anchorElement?.click();
+  }
+
+  public override focus(options?: FocusOptions): void {
+    this.anchorElement?.focus(options);
+  }
+
+  private getItemRole(): NavigationItemRole | undefined {
+    const hostRole = this.getAttribute('role');
+    if (hostRole === NavigationItemRole.MenuItem) {
+      return NavigationItemRole.MenuItem;
+    }
+
+    return this.href === undefined ? NavigationItemRole.Button : undefined;
+  }
+
+  private getItemTabIndex(): number | undefined {
+    const hostTabIndex = this.getAttribute('tabindex');
+    if (hostTabIndex !== null) {
+      const parsedTabIndex = Number(hostTabIndex);
+      return Number.isNaN(parsedTabIndex) ? undefined : parsedTabIndex;
+    }
+
+    return this.href === undefined ? 0 : undefined;
   }
 
   override render() {
@@ -161,6 +203,9 @@ export class ObcNavigationItem extends LitElement {
         })}"
         href=${ifDefined(this.href)}
         @click=${this.onClick}
+        @keydown=${this.handleKeydown}
+        tabindex=${ifDefined(this.getItemTabIndex())}
+        role=${ifDefined(this.getItemRole())}
       >
         <div class="visible-wrapper">
           ${this.hasIcon

--- a/packages/openbridge-webcomponents/src/components/split-button/split-button.ts
+++ b/packages/openbridge-webcomponents/src/components/split-button/split-button.ts
@@ -1,5 +1,5 @@
 import {LitElement, html, unsafeCSS, nothing} from 'lit';
-import {property, state} from 'lit/decorators.js';
+import {property, query, state} from 'lit/decorators.js';
 import compentStyle from './split-button.css?inline';
 import {customElement} from '../../decorator.js';
 import {classMap} from 'lit/directives/class-map.js';
@@ -13,6 +13,7 @@ import {
   ContextMenuOption,
   ColumnGroup,
 } from '../context-menu-input/context-menu-input.js';
+import type {ObcContextMenuInput} from '../context-menu-input/context-menu-input.js';
 
 export type ObcSplitButtonClickEvent = CustomEvent<{
   action: 'primary' | 'dropdown';
@@ -94,8 +95,8 @@ export type ObcSplitButtonChangeEvent = CustomEvent<{
  * In this example, the split button shows a "Save" action with a leading icon, and a dropdown menu with "Save As..." and "Export" options.
  *
  * @slot icon - Leading icon for the primary button (shown when `hasIcon` is true)
- * @fires click {CustomEvent<{action: 'primary' | 'dropdown', value?: string, option?: ContextMenuOption}>} Fired when the primary or dropdown button is clicked.
- * @fires change {CustomEvent<{selectedValues: string[], selectedOptions: Array<ContextMenuOption>}>} Fired when the dropdown menu selection changes.
+ * @fires click {ObcSplitButtonClickEvent} Fired when the primary or dropdown button is clicked.
+ * @fires change {ObcSplitButtonChangeEvent} Fired when the dropdown menu selection changes.
  */
 @customElement('obc-split-button')
 export class ObcSplitButton extends LitElement {
@@ -185,6 +186,14 @@ export class ObcSplitButton extends LitElement {
 
   @state() private isDropdownOpen = false;
 
+  private restoreFocusOnClose = false;
+
+  private menuFocusStrategy: 'first' | 'selected' | 'last' = 'selected';
+
+  @query('obc-context-menu-input') private menu?: ObcContextMenuInput;
+
+  @query('.dropdown-button') private dropdownButton?: HTMLElement;
+
   private handlePrimaryClick = (e: Event) => {
     e.stopPropagation();
     this.dispatchEvent(
@@ -204,6 +213,77 @@ export class ObcSplitButton extends LitElement {
     );
     if (this.isDropdownOpen) {
       window.addEventListener('pointerdown', this.closeOnOutside);
+      void this.focusMenuAfterOpen();
+    } else {
+      window.removeEventListener('pointerdown', this.closeOnOutside);
+    }
+  };
+
+  private async focusMenuAfterOpen() {
+    await this.updateComplete;
+    if (!this.isDropdownOpen) return;
+
+    if (this.menuFocusStrategy === 'last') {
+      this.menu?.focusLastItem();
+    } else if (this.menuFocusStrategy === 'first') {
+      this.menu?.focusFirstItem();
+    } else {
+      this.menu?.focusSelectedItem();
+    }
+
+    this.menuFocusStrategy = 'selected';
+  }
+
+  private handleDropdownKeydown = (event: KeyboardEvent) => {
+    if (this.disabled) return;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.menuFocusStrategy = 'first';
+        if (!this.isDropdownOpen) {
+          this.isDropdownOpen = true;
+          window.addEventListener('pointerdown', this.closeOnOutside);
+          void this.focusMenuAfterOpen();
+        } else {
+          this.menu?.focusFirstItem();
+        }
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.menuFocusStrategy = 'last';
+        if (!this.isDropdownOpen) {
+          this.isDropdownOpen = true;
+          window.addEventListener('pointerdown', this.closeOnOutside);
+          void this.focusMenuAfterOpen();
+        } else {
+          this.menu?.focusLastItem();
+        }
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.menuFocusStrategy = 'first';
+        if (!this.isDropdownOpen) {
+          this.isDropdownOpen = true;
+          window.addEventListener('pointerdown', this.closeOnOutside);
+          void this.focusMenuAfterOpen();
+        } else {
+          this.menu?.focusFirstItem();
+        }
+        break;
+      case 'End':
+        event.preventDefault();
+        this.menuFocusStrategy = 'last';
+        if (!this.isDropdownOpen) {
+          this.isDropdownOpen = true;
+          window.addEventListener('pointerdown', this.closeOnOutside);
+          void this.focusMenuAfterOpen();
+        } else {
+          this.menu?.focusLastItem();
+        }
+        break;
+      default:
+        break;
     }
   };
 
@@ -251,8 +331,15 @@ export class ObcSplitButton extends LitElement {
   }
 
   private handleMenuClose = () => {
+    this.restoreFocusOnClose = true;
     this.isDropdownOpen = false;
     window.removeEventListener('pointerdown', this.closeOnOutside);
+    queueMicrotask(() => {
+      if (this.restoreFocusOnClose) {
+        this.restoreFocusOnClose = false;
+        this.dropdownButton?.focus();
+      }
+    });
   };
 
   override disconnectedCallback() {
@@ -292,6 +379,7 @@ export class ObcSplitButton extends LitElement {
           .disabled=${this.disabled}
           .activated=${this.isDropdownOpen}
           @click=${this.handleDropdownClick}
+          @keydown=${this.handleDropdownKeydown}
           aria-expanded=${this.isDropdownOpen}
           aria-haspopup="menu"
         >


### PR DESCRIPTION
Move the fix to the shared context menu used by both components.

- focus the menu when opened
- support Arrow keys, Home, End, and Escape
- restore focus to the trigger on close
- make shared menu item primitives keyboard-focusable
- keep flyout and multi-column behavior working
- clean up JSDoc to avoid Storybook docs warnings
- closes #810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard navigation for context menus (ArrowUp/Down, Home/End), Escape-to-close, and menu-item discovery/focus helpers.
  * Public focus helpers: focus first/last/selected menu item; focus forwarding added to checkbox items, navigation item groups, and navigation items.
  * Keyboard activation for navigation items (Enter/Space) and enhanced keyboard handling on dropdown/split triggers with focus strategies and restore-on-close.

* **Documentation**
  * JSDoc event annotations updated to reference exported typed event aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->