### PR TITLE
docs(a11y): add keyboard navigation and WCAG 2.1 AA instructions

### DIFF
--- a/.github/instructions/a11y.instructions.md
+++ b/.github/instructions/a11y.instructions.md
@@ -14,7 +14,8 @@ Every interactive element must be reachable and operable with the keyboard alone
 
 ### Reachability
 
-- Prefer native focusable elements (`<button>`, `<a>`, `<input>`, `<select>`, `<textarea>`) inside the component's shadow DOM. They come with correct focus, activation, and semantics for free.
+- Prefer native focusable elements (`<button>`, `<a>`, `<input>`, `<select>`, `<textarea>`) inside the component's shadow DOM for their focus, activation, and semantic behavior.
+- **Do not silently swap a non-native element for a native one in an existing component.** Changing a `<div>` wrapper to a `<button>` can break layout, event bubbling, form submission, ARIA overrides, and visual regression snapshots. If a component currently uses a non-native element and would benefit from a native one, **propose the change and wait for user confirmation** before implementing it.
 - When the component's host element itself is the interactive target (no native element inside), make the host focusable by setting `tabindex="0"` on the outer touch-target wrapper — not on `:host` directly, so parent components can still override tab order.
 - Never put `tabindex` values greater than `0`. Use DOM order to control tab sequence.
 - A `disabled` interactive component must be removed from the tab order (native elements do this automatically; for custom wrappers use `tabindex="-1"` when `disabled`).

--- a/.github/instructions/a11y.instructions.md
+++ b/.github/instructions/a11y.instructions.md
@@ -1,0 +1,101 @@
+---
+applyTo: "packages/openbridge-webcomponents/src/components/**, packages/openbridge-webcomponents/src/automation/**"
+---
+
+# Accessibility Instructions
+
+These instructions apply to all interactive UI components and automation components. Target: **WCAG 2.1 AA**. The primary focus is **keyboard navigation** — every new interactive component must be fully operable without a mouse.
+
+Display-only SVG instruments (navigation-instruments, building-blocks, bars-graphs) are out of scope unless they expose interactive affordances (e.g. draggable setpoints).
+
+## 1. Keyboard Navigation
+
+Every interactive element must be reachable and operable with the keyboard alone.
+
+### Reachability
+
+- Prefer native focusable elements (`<button>`, `<a>`, `<input>`, `<select>`, `<textarea>`) inside the component's shadow DOM. They come with correct focus, activation, and semantics for free.
+- When the component's host element itself is the interactive target (no native element inside), make the host focusable by setting `tabindex="0"` on the outer touch-target wrapper — not on `:host` directly, so parent components can still override tab order.
+- Never put `tabindex` values greater than `0`. Use DOM order to control tab sequence.
+- A `disabled` interactive component must be removed from the tab order (native elements do this automatically; for custom wrappers use `tabindex="-1"` when `disabled`).
+
+### Activation keys
+
+| Element                           | Keys that must activate             |
+| --------------------------------- | ----------------------------------- |
+| Button, toggle, checkbox          | `Enter` and `Space`                 |
+| Link                              | `Enter` only                        |
+| Radio, tab in a tablist           | Arrow keys to move, `Space` to select |
+| Menu / dropdown                   | Arrow keys to move, `Enter` to select, `Escape` to close |
+| Slider, stepper                   | Arrow keys to change value, `Home`/`End` for extremes |
+| Modal, dialog, overlay            | `Escape` to dismiss                 |
+
+Pattern for custom activation handlers:
+
+```ts
+private handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    this.activate();
+  }
+}
+```
+
+### Composite widgets
+
+Groups of related controls (tab groups, radio groups, menus, toolbars) use a single tab stop with arrow-key navigation inside the group — not one tab stop per item. Follow the WAI-ARIA Authoring Practices pattern for the widget type.
+
+### Focus trapping
+
+- Do **not** trap focus in normal components.
+- Modal dialogs **must** trap focus while open and restore focus to the invoking element on close.
+- `Escape` must close the modal.
+
+## 2. Focus Indication
+
+- The `@mixin style` already renders a `:focus-visible` ring across all six interaction states. Do not override or disable it.
+- Never write `outline: none` without providing a visible replacement of equal or better prominence.
+- The focus ring belongs on the **touch-target** layer (outer wrapper), not the visible wrapper — this matches the two-layer DOM convention described in `AGENTS.md` § 7.
+- Verify the ring is visible in all four themes (`day`, `dusk`, `night`, `bright`) before merging.
+
+## 3. ARIA & Semantics
+
+- If a native element does the job, use it; don't reach for `role=` when `<button>` works.
+- Custom wrappers that act as a button/checkbox/etc. must declare a matching `role` and mirror the relevant state attributes:
+
+  | State              | Attribute                                         |
+  | ------------------ | ------------------------------------------------- |
+  | Pressed toggle     | `aria-pressed="true\|false"`                      |
+  | Expanded disclosure | `aria-expanded="true\|false"`                    |
+  | Selected tab/option | `aria-selected="true\|false"`                    |
+  | Checked checkbox/radio | `aria-checked="true\|false\|mixed"`            |
+  | Disabled           | `aria-disabled="true"` **or** native `disabled` attribute |
+  | Current page/step  | `aria-current="page\|step\|…"`                    |
+
+- Interactive components without visible text need `aria-label` or `aria-labelledby`. Icon-only buttons fall in this category.
+- Alert/alarm surfaces should use `role="alert"` or an `aria-live` region so screen readers announce state changes.
+- Grouped controls need a group label: `aria-labelledby` pointing at a heading, or `aria-label` on the group element.
+
+## 4. Disabled vs `aria-disabled`
+
+- `disabled` (HTML attribute) — removes the element from the tab order and disables activation. Preferred for buttons and form controls.
+- `aria-disabled="true"` — keeps the element in the tab order but announces it as unavailable. Use only when the element must remain focusable (e.g. a disabled item that still shows a tooltip explaining why).
+- The existing `disabled` boolean property on components should map to the HTML attribute unless a design reason dictates otherwise.
+
+## 5. Color & Contrast
+
+- **Never hardcode colors or guess contrast values.** The correct palette tokens live in Figma and are mirrored in `src/palettes/variables.css`.
+- Use the existing CSS variables for all backgrounds, borders, text, and icons. If a needed token is missing, ask the designer — do not invent a fallback hex.
+- Four themes (`day`, `dusk`, `night`, `bright`) are already contrast-checked. Custom color choices bypass this guarantee.
+- Icon and text colors follow the `--on-{variant}-{role}-color` convention; use `active`, `neutral`, or `disabled` roles as defined in `AGENTS.md` § 7.
+
+## 6. Testing Checklist
+
+Before marking an interactive component as done:
+
+1. **Tab through** the component in a story — every interactive element receives focus in a sensible order.
+2. **Activate with keyboard only** — `Enter`, `Space`, arrow keys, `Escape` behave per the table in § 1.
+3. **Focus ring** is visible in all four themes.
+4. **Screen-reader smoke test** — run NVDA (Windows), VoiceOver (macOS), or Orca (Linux) and confirm the component announces its role, label, and state.
+5. **Disabled state** is skipped by `Tab` (unless deliberately using `aria-disabled`).
+6. **Modal focus trap** (if applicable) — `Tab` cycles within the modal; `Escape` closes and returns focus to the invoker.

--- a/.github/instructions/a11y.instructions.md
+++ b/.github/instructions/a11y.instructions.md
@@ -22,14 +22,19 @@ Every interactive element must be reachable and operable with the keyboard alone
 
 ### Activation keys
 
-| Element                           | Keys that must activate             |
-| --------------------------------- | ----------------------------------- |
-| Button, toggle, checkbox          | `Enter` and `Space`                 |
-| Link                              | `Enter` only                        |
-| Radio, tab in a tablist           | Arrow keys to move, `Space` to select |
-| Menu / dropdown                   | Arrow keys to move, `Enter` to select, `Escape` to close |
-| Slider, stepper                   | Arrow keys to change value, `Home`/`End` for extremes |
-| Modal, dialog, overlay            | `Escape` to dismiss                 |
+| Element                                                        | Keys that must activate                                                     |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Button, toggle                                                 | `Enter` and `Space`                                                         |
+| Checkbox                                                       | `Space` only (per WAI-ARIA APG — `Enter` is not part of the checkbox pattern) |
+| Link                                                           | `Enter` only                                                                |
+| Radio group                                                    | Arrow keys move focus **and** change selection in one step; `Space` checks a focused-but-unchecked radio (edge case, e.g. when nested in a toolbar) |
+| Tabs — manual activation (default)                             | Arrow keys move focus between tabs; `Enter` or `Space` activates the focused tab and shows its panel |
+| Tabs — automatic activation (only when panels preload with no perceptible latency) | Arrow keys move focus and activate the panel simultaneously                 |
+| Menu / dropdown                                                | Arrow keys to move, `Enter` to select, `Escape` to close                    |
+| Slider, stepper                                                | Arrow keys to change value, `Home`/`End` for extremes                       |
+| Modal, dialog, overlay                                         | `Escape` to dismiss                                                         |
+
+Tab activation defaults to **manual**. Only switch to automatic activation when every tab panel's content is already loaded in the DOM and there is no user-perceptible latency on activation — otherwise automatic activation slows keyboard users who are just trying to traverse the tab list. Follow the WAI-ARIA APG tabs pattern for the full specification.
 
 Pattern for custom activation handlers:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,7 @@ Agents that support glob-scoped instructions should apply them automatically.
 | `setpoint.instructions.md`                 | `svghelpers/setpoint*.ts`, `building-blocks/setpoint/**`                                                                                                                       | Setpoint design layer, mixin/bundle, confirm animation    |
 | `automation-components.instructions.md`    | `automation/**`                                                                                                                                                                | Automation devices, valves, lines, tanks, badges          |
 | `ui-components.instructions.md`            | `components/**`                                                                                                                                                                | General UI components (buttons, cards, inputs, feedback)  |
+| `a11y.instructions.md`                     | `components/**`, `automation/**`                                                                                                                                               | Accessibility (WCAG 2.1 AA) — keyboard nav, ARIA, focus   |
 
 ---
 
@@ -265,25 +266,26 @@ Required modifications after pasting:
 1. **Read before writing.** Always read the relevant source, story, and instruction file before modifying a component.
 2. **Follow the three-pattern strategy** (§ 3) when writing or updating JSDoc.
 3. **Respect glob-scoped instructions** (§ 4) — read the matching `.instructions.md` file when touching files in its scope.
-4. **Do not edit auto-generated packages** (`-react`, `-vue`, `-ng`, `-svelte`). Run `npm run wrappers` instead.
-5. **Run `npm run analyze`** after adding or renaming a `@customElement` to keep `custom-elements.json` in sync.
-6. **Run `npm run lint`** after code changes to catch issues early.
-7. **Insert `TODO(designer)`** for any documentation detail whose purpose is unclear from code alone.
-8. **Keep stories tagged** with `['autodocs', '6.0']` for documented OB 6.0 components; `['alpha']` for in-development; `['skip-test']` to exclude from visual tests.
-9. **Do not run full builds or start Storybook automatically.** Avoid `npm run build`, `npm run storybook` unless the user explicitly requests it. These are expensive, long-running operations.
-10. **Run visual tests for a single component** instead of the full suite:
+4. **Accessibility is required for interactive components.** Every new or modified component in `src/components/**` or `src/automation/**` must support full keyboard navigation and meet WCAG 2.1 AA. Read [`.github/instructions/a11y.instructions.md`](.github/instructions/a11y.instructions.md) for the activation-key table, ARIA rules, focus handling, and testing checklist before writing or changing an interactive component.
+5. **Do not edit auto-generated packages** (`-react`, `-vue`, `-ng`, `-svelte`). Run `npm run wrappers` instead.
+6. **Run `npm run analyze`** after adding or renaming a `@customElement` to keep `custom-elements.json` in sync.
+7. **Run `npm run lint`** after code changes to catch issues early.
+8. **Insert `TODO(designer)`** for any documentation detail whose purpose is unclear from code alone.
+9. **Keep stories tagged** with `['autodocs', '6.0']` for documented OB 6.0 components; `['alpha']` for in-development; `['skip-test']` to exclude from visual tests.
+10. **Do not run full builds or start Storybook automatically.** Avoid `npm run build`, `npm run storybook` unless the user explicitly requests it. These are expensive, long-running operations.
+11. **Run visual tests for a single component** instead of the full suite:
     ```bash
     npx vitest run --project storybook 'component-name'
     ```
-11. **Update baselines for a single component:**
+12. **Update baselines for a single component:**
     ```bash
     npx vitest run --project storybook --update 'component-name'
     ```
-12. **Always verify after updating baselines** — re-run the test without `--update` to confirm the new baselines are stable:
+13. **Always verify after updating baselines** — re-run the test without `--update` to confirm the new baselines are stable:
     ```bash
     npx vitest run --project storybook 'component-name'
     ```
-13. **Keep the main context clean.** Delegate broad codebase exploration to subagents; only read files directly in the main thread when you are about to edit them or need a few specific lines.
+14. **Keep the main context clean.** Delegate broad codebase exploration to subagents; only read files directly in the main thread when you are about to edit them or need a few specific lines.
 
 ---
 


### PR DESCRIPTION
## Summary
- New path-scoped instruction file [`.github/instructions/a11y.instructions.md`](.github/instructions/a11y.instructions.md) covering keyboard navigation (activation keys, composite widgets, focus trap rules), focus indication via `@mixin style`, ARIA semantics, `disabled` vs `aria-disabled`, palette-token-only color rule, and a testing checklist.
- Scoped to `src/components/**` and `src/automation/**` — the interactive surfaces.
- Target: WCAG 2.1 AA, with keyboard navigation as the primary focus.
- Registered in [`AGENTS.md` § 4](AGENTS.md) table and added as explicit behavioral rule 4 in § 8 so AI agents pick it up before modifying interactive components.

## Test plan
- [ ] Team review of the rules themselves — activation-key table, ARIA state attribute list, testing checklist items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive WCAG 2.1 AA–targeted accessibility guidelines covering keyboard navigation (tab/arrow/activation semantics), focus behavior and trapping, visible focus rings across themes, ARIA/semantic and disabled semantics, announcements, and composite widget patterns.
  * Updated contributor/process instructions to require accessibility checks (tab traversal, keyboard activation, focus-ring visibility, screen-reader announcements, disabled behavior, modal focus-trap) before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->