### PR TITLE
feat(ROT)!: change API to rateOfTurnDegreesPerMinute

### DIFF
--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-flat/compass-flat.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-flat/compass-flat.stories.ts
@@ -42,6 +42,17 @@ const meta: Meta<typeof ObcCompassFlat> = {
     },
     rotationsPerMinute: {
       control: {type: 'range', min: -10, max: 10, step: 0.5},
+      description: '**Deprecated.** Use `rateOfTurnDegreesPerMinute` instead.',
+    },
+    rateOfTurnDegreesPerMinute: {
+      control: {type: 'range', min: -180, max: 180, step: 1},
+      description:
+        'Measured rate of turn in degrees per minute (positive = starboard).',
+    },
+    rotDotAnimationFactor: {
+      control: {type: 'range', min: 1, max: 60, step: 1},
+      description:
+        'Visual amplification for the dot animation only (not bar extent).',
     },
     rotMaxValue: {control: {type: 'range', min: 1, max: 60, step: 1}},
     rotArcExtent: {control: {type: 'range', min: 10, max: 180, step: 5}},
@@ -96,5 +107,17 @@ export const WithRotBarWideFOV: Story = {
     heading: 0,
     courseOverGround: 150,
     minFOV: 90,
+  },
+};
+
+export const WithRateOfTurnDegreesPerMinute: Story = {
+  name: 'Rate of Turn Degrees Per Minute',
+  tags: ['skip-test'],
+  args: {
+    rotType: RotType.bar,
+    rateOfTurnDegreesPerMinute: 20,
+    rotDotAnimationFactor: 18,
+    rotMaxValue: 60,
+    courseOverGround: 80,
   },
 };

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-flat/compass-flat.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-flat/compass-flat.ts
@@ -61,8 +61,10 @@ export interface Label {
  * @property {number} heading - Current heading in degrees.
  * @property {number} courseOverGround - Current COG in degrees.
  * @property {RotType|undefined} rotType - ROT display mode: `'dots'`, `'bar'`, or `undefined` (hidden).
- * @property {number} rotationsPerMinute - ROT spin speed; sign controls direction.
- * @property {number} rotMaxValue - Maximum ROT value for bar-extent mapping.
+ * @property {number|undefined} rateOfTurnDegreesPerMinute - Measured rate of turn in degrees per minute (positive = starboard). Drives the bar extent and (after `× rotDotAnimationFactor`) the dot animation.
+ * @property {number} rotDotAnimationFactor - Visual amplification for the dot animation only. Default `18` (≈1 rpm at 20°/min).
+ * @property {number} rotationsPerMinute - **Deprecated.** Use `rateOfTurnDegreesPerMinute` instead.
+ * @property {number} rotMaxValue - Bar-extent reference value in **degrees per minute**. Default `60` per ES-TRIN 2025/1 Art. 3.02.
  * @property {number} rotArcExtent - Degrees of bar arc per max-value ROT (default 60).
  *
  * @ignition-base-height: 170px
@@ -83,8 +85,24 @@ export class ObcCompassFlat extends LitElement {
     CompassFlatPriorityElement.hdg,
   ];
   @property({type: String}) rotType: RotType | undefined;
+  /**
+   * Measured rate of turn in degrees per minute (positive = starboard).
+   * When `undefined`, falls back to the deprecated `rotationsPerMinute`.
+   */
+  @property({type: Number}) rateOfTurnDegreesPerMinute: number | undefined;
+  /**
+   * Visual amplification applied only to the spinning dot animation.
+   */
+  @property({type: Number}) rotDotAnimationFactor: number = 18;
+  /**
+   * @deprecated Use `rateOfTurnDegreesPerMinute` instead.
+   */
   @property({type: Number}) rotationsPerMinute: number = 1;
-  @property({type: Number}) rotMaxValue: number = 10;
+  /**
+   * Bar-extent reference value in **degrees per minute**. Default `60`
+   * per ES-TRIN 2025/1 Art. 3.02.
+   */
+  @property({type: Number}) rotMaxValue: number = 60;
   @property({type: Number}) rotArcExtent: number = 60;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
   @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
@@ -246,6 +264,10 @@ export class ObcCompassFlat extends LitElement {
     return selected.includes(element) ? this.priority : Priority.regular;
   }
 
+  private get _effectiveRotDegPerMin(): number {
+    return this.rateOfTurnDegreesPerMinute ?? this.rotationsPerMinute;
+  }
+
   private arrowColorFor(element: CompassFlatPriorityElement): string {
     return this.priorityFor(element) === Priority.enhanced
       ? 'var(--instrument-enhanced-secondary-color)'
@@ -305,10 +327,12 @@ export class ObcCompassFlat extends LitElement {
           .bottomBar=${!!this.rotType}
           .rotType=${this.rotType}
           .rotStartX=${0}
-          .rotEndX=${(this.rotationsPerMinute / (this.rotMaxValue || 1)) *
+          .rotEndX=${(this._effectiveRotDegPerMin / (this.rotMaxValue || 1)) *
           this.rotArcExtent *
           translationScale}
           .rotDotSpacing=${LINEAR_DOT_ANGLE_SPACING * translationScale}
+          .rateOfTurnDegreesPerMinute=${this.rateOfTurnDegreesPerMinute}
+          .rotDotAnimationFactor=${this.rotDotAnimationFactor}
           .rotationsPerMinute=${this.rotationsPerMinute}
           .rotPriority=${this.priorityFor(CompassFlatPriorityElement.rot)}
           .rotPortStarboard=${this.rotPortStarboard}

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-sector/compass-sector.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-sector/compass-sector.stories.ts
@@ -39,6 +39,17 @@ const meta: Meta<typeof ObcCompassSector> = {
     minFOV: {control: {type: 'range', min: 5, max: 180, step: 5}},
     rotationsPerMinute: {
       control: {type: 'range', min: -10, max: 10, step: 0.1},
+      description: '**Deprecated.** Use `rateOfTurnDegreesPerMinute` instead.',
+    },
+    rateOfTurnDegreesPerMinute: {
+      control: {type: 'range', min: -180, max: 180, step: 1},
+      description:
+        'Measured rate of turn in degrees per minute (positive = starboard).',
+    },
+    rotDotAnimationFactor: {
+      control: {type: 'range', min: 1, max: 60, step: 1},
+      description:
+        'Visual amplification for the dot animation only (not bar extent).',
     },
     rotMaxValue: {control: {type: 'range', min: 1, max: 60, step: 1}},
     rotType: {
@@ -155,6 +166,21 @@ export const WithRotBarEnhanced: Story = {
     headingSetpoint: 311,
     rotType: RotType.bar,
     rotationsPerMinute: 5,
+    priorityElements: [
+      CompassSectorPriorityElement.hdg,
+      CompassSectorPriorityElement.rot,
+    ],
+  },
+};
+
+export const WithRateOfTurnDegreesPerMinute: Story = {
+  tags: ['skip-test'],
+  args: {
+    headingSetpoint: 311,
+    rotType: RotType.bar,
+    rateOfTurnDegreesPerMinute: 20,
+    rotDotAnimationFactor: 18,
+    rotMaxValue: 60,
     priorityElements: [
       CompassSectorPriorityElement.hdg,
       CompassSectorPriorityElement.rot,

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-sector/compass-sector.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-sector/compass-sector.ts
@@ -116,8 +116,34 @@ export class ObcCompassSector extends LitElement {
 
   @property({type: String}) rotType: RotType | undefined;
   @property({type: String}) rotPosition: RotPosition = RotPosition.innerCircle;
+  /**
+   * Measured rate of turn in degrees per minute (positive = starboard).
+   * Drives both the bar extent and (after multiplication by
+   * `rotDotAnimationFactor`) the spinning dot animation. When `undefined`,
+   * falls back to the deprecated `rotationsPerMinute`.
+   */
+  @property({type: Number}) rateOfTurnDegreesPerMinute: number | undefined;
+  /**
+   * Visual amplification applied only to the spinning dot animation
+   * (not to the bar extent). Default `18` keeps the legacy visual feel
+   * (≈1 rpm at 20°/min).
+   */
+  @property({type: Number}) rotDotAnimationFactor: number = 18;
+  /**
+   * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally
+   * `rotDotAnimationFactor`) instead. Takes effect only when
+   * `rateOfTurnDegreesPerMinute` is `undefined`.
+   */
   @property({type: Number}) rotationsPerMinute: number = 1;
-  @property({type: Number}) rotMaxValue: number = 10;
+  /**
+   * Bar-extent reference value in **degrees per minute**. The bar fills the
+   * full ±`ARC_HALF_EXTENT` arc when the measured ROT equals
+   * ±`rotMaxValue`. Default `60` aligns with ES-TRIN 2025/1 Art. 3.02.
+   *
+   * Note: the unit changed from rotations per minute to degrees per minute
+   * with the introduction of `rateOfTurnDegreesPerMinute`.
+   */
+  @property({type: Number}) rotMaxValue: number = 60;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
   @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
 
@@ -352,9 +378,14 @@ export class ObcCompassSector extends LitElement {
     });
   }
 
+  private get _effectiveRotDegPerMin(): number {
+    return this.rateOfTurnDegreesPerMinute ?? this.rotationsPerMinute;
+  }
+
   private get _rotEndAngle(): number {
     const maxVal = this.rotMaxValue || 1;
-    const barCompassDeg = (this.rotationsPerMinute / maxVal) * ARC_HALF_EXTENT;
+    const barCompassDeg =
+      (this._effectiveRotDegPerMin / maxVal) * ARC_HALF_EXTENT;
     return this._mapAngle(this.heading + barCompassDeg);
   }
 
@@ -415,6 +446,8 @@ export class ObcCompassSector extends LitElement {
           .rotPriority=${this.priorityFor(CompassSectorPriorityElement.rot)}
           .rotPortStarboard=${this.rotPortStarboard}
           .rotAtZeroDeadband=${this.rotAtZeroDeadband}
+          .rateOfTurnDegreesPerMinute=${this.rateOfTurnDegreesPerMinute}
+          .rotDotAnimationFactor=${this.rotDotAnimationFactor}
           .rotationsPerMinute=${this.rotationsPerMinute}
         >
         </obc-watch>

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.stories.ts
@@ -58,7 +58,17 @@ const meta: Meta<typeof ObcCompass> = {
     rotationsPerMinute: {
       control: {type: 'range', min: -10, max: 10, step: 0.1},
       description:
-        'Rotations per minute. NB: storybook recreates the component on change, which resets the animation.',
+        '**Deprecated.** Use `rateOfTurnDegreesPerMinute` instead. NB: storybook recreates the component on change, which resets the animation.',
+    },
+    rateOfTurnDegreesPerMinute: {
+      control: {type: 'range', min: -180, max: 180, step: 1},
+      description:
+        'Measured rate of turn in degrees per minute (positive = starboard). Drives both the bar extent and (after multiplication by `rotDotAnimationFactor`) the dot animation.',
+    },
+    rotDotAnimationFactor: {
+      control: {type: 'range', min: 1, max: 60, step: 1},
+      description:
+        'Visual amplification applied only to the spinning dot animation (not bar extent). Default `18` (≈1 rpm at 20°/min).',
     },
     rotType: {
       control: 'select',
@@ -144,6 +154,17 @@ export const WithRotBarEnhanced: Story = {
   args: {
     rotType: RotType.bar,
     rotationsPerMinute: 5,
+    priorityElements: [CompassPriorityElement.hdg, CompassPriorityElement.rot],
+  },
+};
+
+export const WithRateOfTurnDegreesPerMinute: Story = {
+  tags: ['skip-test'],
+  args: {
+    rotType: RotType.bar,
+    rateOfTurnDegreesPerMinute: 20,
+    rotDotAnimationFactor: 18,
+    rotMaxValue: 60,
     priorityElements: [CompassPriorityElement.hdg, CompassPriorityElement.rot],
   },
 };

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.ts
@@ -54,10 +54,14 @@ export enum CompassPriorityElement {
  * - **Advice zones**: Pass `headingAdvices` to render caution/alert arcs;
  *   triggered state is derived from whether the current heading falls
  *   inside the advice range.
- * - **Rate of turn**: Animated ROT indicator driven by `rotationsPerMinute`.
- *   Supports spinning dots (`rotType="dots"`) and a banana-shaped arc bar
- *   (`rotType="bar"`) showing the HDG→COG span. Position on the outer
- *   scale ring or inner circle via `rotPosition`.
+ * - **Rate of turn**: Animated ROT indicator driven by
+ *   `rateOfTurnDegreesPerMinute` (deg/min, the maritime / AIS convention).
+ *   Supports spinning dots (`rotType="dots"`) — the dot animation is
+ *   amplified by `rotDotAnimationFactor` so small physical values still
+ *   read at a glance — and a banana-shaped arc bar (`rotType="bar"`)
+ *   showing the HDG→COG span. Bar extent is driven by the physical value
+ *   only (gain is not applied). Position on the outer scale ring or inner
+ *   circle via `rotPosition`.
  * - **Environmental overlays**: Wind speed/direction and current
  *   speed/direction indicators on the watch face.
  * - **Vessel image**: Configurable vessel silhouette centered on the
@@ -103,7 +107,9 @@ export enum CompassPriorityElement {
  * @property {number | null} currentSpeed - The current speed, number of arrows.
  * @property {number | null} currentFromDirection - The direction the current is coming from in degrees.
  * @property {VesselImage} vesselImage - The image of the vessel.
- * @property {number} rotationsPerMinute - The number of rotations per minute for the rate of turn controller.
+ * @property {number|undefined} rateOfTurnDegreesPerMinute - Measured rate of turn in degrees per minute (the AIS / ITU-R M.1371 convention). Sign controls direction (positive = starboard / clockwise). Drives both the bar extent and the dot animation.
+ * @property {number} rotDotAnimationFactor - Visual amplification for the dot animation only. Default `18` (≈1 rpm at 20°/min).
+ * @property {number} rotationsPerMinute - **Deprecated.** Use `rateOfTurnDegreesPerMinute` instead. Kept as a backward-compatible fallback when `rateOfTurnDegreesPerMinute` is `undefined`.
  * @property {RotType} rotType - ROT display mode: `'dots'` (spinning dots, default) or `'bar'` (arc bar from HDG to COG).
  * @property {RotPosition} rotPosition - ROT track position: `'innerCircle'` (default) or `'scale'` (on the outer ring).
  * @property {Priority} priority - Color priority: `Priority.enhanced` uses the blue/enhanced color palette, `Priority.regular` (default) uses the standard palette.
@@ -132,10 +138,37 @@ export class ObcCompass extends LitElement {
   @property({type: Number}) currentSpeed: number | null = null;
   @property({type: Number}) currentFromDirection: number | null = null;
   @property({type: String}) vesselImage: VesselImage = VesselImage.genericTop;
+  /**
+   * Measured rate of turn in degrees per minute (positive = starboard).
+   * Drives both the bar extent and (after multiplication by
+   * `rotDotAnimationFactor`) the spinning dot animation.
+   * When `undefined`, falls back to the deprecated `rotationsPerMinute`.
+   */
+  @property({type: Number}) rateOfTurnDegreesPerMinute: number | undefined;
+  /**
+   * Visual amplification applied only to the spinning dot animation
+   * (not to the bar extent). Default `18` keeps the legacy visual feel
+   * (≈1 rpm at 20°/min).
+   */
+  @property({type: Number}) rotDotAnimationFactor: number = 18;
+  /**
+   * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally
+   * `rotDotAnimationFactor`) instead. Takes effect only when
+   * `rateOfTurnDegreesPerMinute` is `undefined`.
+   */
   @property({type: Number}) rotationsPerMinute: number = 1;
   @property({type: String}) rotType: RotType = RotType.dots;
   @property({type: String}) rotPosition: RotPosition = RotPosition.innerCircle;
-  @property({type: Number}) rotMaxValue: number = 10;
+  /**
+   * Bar-extent reference value in **degrees per minute**. The bar fills the
+   * full ±`rotArcExtent` arc when the measured ROT equals ±`rotMaxValue`.
+   * Default `60` aligns with ES-TRIN 2025/1 Art. 3.02.
+   *
+   * Note: prior to the introduction of `rateOfTurnDegreesPerMinute` this
+   * property was interpreted in rotations per minute. The unit changed when
+   * the physical ROT API was introduced.
+   */
+  @property({type: Number}) rotMaxValue: number = 60;
   @property({type: Number}) rotArcExtent: number = 60;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
   @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
@@ -178,6 +211,16 @@ export class ObcCompass extends LitElement {
   // @ts-expect-error TS6133: The controller ensures that the render
   // function is called on resize of the element
   private _resizeController = new ResizeController(this, {});
+
+  /**
+   * Resolved rate of turn in degrees per minute, used to compute the bar
+   * extent. Prefers the new physical API; falls back to the deprecated
+   * `rotationsPerMinute` so existing consumers keep their visuals during
+   * the deprecation window.
+   */
+  private get _effectiveRotDegPerMin(): number {
+    return this.rateOfTurnDegreesPerMinute ?? this.rotationsPerMinute;
+  }
 
   private getPadding() {
     const size = Math.min(this.clientHeight, this.clientWidth);
@@ -279,12 +322,14 @@ export class ObcCompass extends LitElement {
           .rotPosition=${this.rotPosition}
           .rotStartAngle=${this.heading + (this.getRotation() ?? 0)}
           .rotEndAngle=${this.heading +
-          (this.rotationsPerMinute / (this.rotMaxValue || 1)) *
+          (this._effectiveRotDegPerMin / (this.rotMaxValue || 1)) *
             this.rotArcExtent +
           (this.getRotation() ?? 0)}
           .rotPriority=${this.priorityFor(CompassPriorityElement.rot)}
           .rotPortStarboard=${this.rotPortStarboard}
           .rotAtZeroDeadband=${this.rotAtZeroDeadband}
+          .rateOfTurnDegreesPerMinute=${this.rateOfTurnDegreesPerMinute}
+          .rotDotAnimationFactor=${this.rotDotAnimationFactor}
           .rotationsPerMinute=${this.rotationsPerMinute}
         >
         </obc-watch>

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rate-of-turn/rate-of-turn.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rate-of-turn/rate-of-turn.stories.ts
@@ -23,7 +23,17 @@ const meta: Meta<typeof ObcRateOfTurn> = {
     rotationsPerMinute: {
       control: {type: 'range', min: -10, max: 10, step: 0.1},
       description:
-        'rotations per minute. NB: storybook recreates the component on change, which resets the animation.',
+        '**Deprecated.** Use `rateOfTurnDegreesPerMinute` instead. NB: storybook recreates the component on change, which resets the animation.',
+    },
+    rateOfTurnDegreesPerMinute: {
+      control: {type: 'range', min: -180, max: 180, step: 1},
+      description:
+        'Measured rate of turn in degrees per minute (positive = starboard).',
+    },
+    rotDotAnimationFactor: {
+      control: {type: 'range', min: 1, max: 60, step: 1},
+      description:
+        'Visual amplification for the dot animation. Default `18` (≈1 rpm at 20°/min).',
     },
     rotType: {control: 'select', options: Object.values(RotType)},
     rotPosition: {control: 'select', options: Object.values(RotPosition)},
@@ -109,5 +119,19 @@ export const Demo: Story = {
       t += 1;
     }, 1000);
     return rateOfTurn;
+  },
+};
+
+export const RateOfTurnDegreesPerMinute: Story = {
+  tags: ['skip-test'],
+  args: {
+    rotType: RotType.bar,
+    rateOfTurnDegreesPerMinute: 20,
+    rotDotAnimationFactor: 18,
+    barStartAngle: 0,
+    barEndAngle: 30,
+    rotPosition: RotPosition.innerCircle,
+    watchCircleType: WatchCircleType.triple,
+    rotPortStarboard: true,
   },
 };

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rate-of-turn/rate-of-turn.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rate-of-turn/rate-of-turn.ts
@@ -18,7 +18,8 @@ export {RotType, RotPosition};
  * ## Features
  *
  * - **Dot mode** (`rotType="dots"`): Five evenly-spaced dots spin at the
- *   configured `rotationsPerMinute`.
+ *   resolved rotations-per-minute (derived from
+ *   `rateOfTurnDegreesPerMinute × rotDotAnimationFactor / 360`).
  * - **Bar mode** (`rotType="bar"`): A banana-shaped arc from `barStartAngle`
  *   to `barEndAngle` with clipped spinning dots inside.
  * - **Track position**: Place the indicator on the outer scale ring
@@ -29,8 +30,11 @@ export {RotType, RotPosition};
  *
  * ## Usage Guidelines
  *
- * - Set `rotationsPerMinute` to the current sensor value; sign controls
- *   spin direction (positive = clockwise).
+ * - Set `rateOfTurnDegreesPerMinute` to the current sensor value in degrees
+ *   per minute (the maritime/AIS convention). Sign controls direction
+ *   (positive = starboard / clockwise).
+ * - Tune `rotDotAnimationFactor` to amplify the dot animation independently
+ *   of the physical value (default `18` ≈ 1 rpm at 20°/min).
  * - In bar mode, `barStartAngle` and `barEndAngle` define the static arc
  *   span (0° = 12 o'clock, clockwise).
  * - Change `watchCircleType` to match the surrounding instrument ring style
@@ -40,6 +44,23 @@ export {RotType, RotPosition};
  */
 @customElement('obc-rate-of-turn')
 export class ObcRateOfTurn extends LitElement {
+  /**
+   * Measured rate of turn in degrees per minute (positive = starboard).
+   * When `undefined`, the legacy `rotationsPerMinute` value is used.
+   */
+  @property({type: Number}) rateOfTurnDegreesPerMinute: number | undefined;
+
+  /**
+   * Visual amplification applied to the spinning dot animation. Default `18`
+   * keeps the legacy visual feel (≈1 rpm at 20°/min).
+   */
+  @property({type: Number}) rotDotAnimationFactor: number = 18;
+
+  /**
+   * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally
+   * `rotDotAnimationFactor`) instead. Takes effect only when
+   * `rateOfTurnDegreesPerMinute` is `undefined`.
+   */
   @property({type: Number}) rotationsPerMinute: number = 1;
 
   @property({type: String}) rotType: RotType = RotType.dots;
@@ -81,6 +102,8 @@ export class ObcRateOfTurn extends LitElement {
         .rotPosition=${this.rotPosition}
         .rotStartAngle=${this.barStartAngle}
         .rotEndAngle=${this.barEndAngle}
+        .rateOfTurnDegreesPerMinute=${this.rateOfTurnDegreesPerMinute}
+        .rotDotAnimationFactor=${this.rotDotAnimationFactor}
         .rotationsPerMinute=${this.rotationsPerMinute}
         .rotPortStarboard=${this.rotPortStarboard}
         .rotAtZeroDeadband=${this.rotAtZeroDeadband}

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rot-indicator/rot-indicator.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rot-indicator/rot-indicator.stories.ts
@@ -15,6 +15,16 @@ const meta: Meta<typeof ObcRotIndicator> = {
         max: 3,
         step: 0.1,
       },
+      description: '**Deprecated.** Use `rateOfTurnDegreesPerMinute` instead.',
+    },
+    rateOfTurnDegreesPerMinute: {
+      control: {type: 'range', min: -180, max: 180, step: 1},
+      description:
+        'Measured rate of turn in degrees per minute (positive = starboard).',
+    },
+    rotDotAnimationFactor: {
+      control: {type: 'range', min: 1, max: 60, step: 1},
+      description: 'Visual amplification for the spinning dot animation.',
     },
   },
 } satisfies Meta<ObcRotIndicator>;
@@ -24,4 +34,12 @@ type Story = StoryObj<ObcRotIndicator>;
 
 export const Primary: Story = {
   args: {},
+};
+
+export const RateOfTurnDegreesPerMinute: Story = {
+  tags: ['skip-test'],
+  args: {
+    rateOfTurnDegreesPerMinute: 20,
+    rotDotAnimationFactor: 18,
+  },
 };

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rot-indicator/rot-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rot-indicator/rot-indicator.ts
@@ -6,16 +6,48 @@ import {customElement} from '../../decorator.js';
 
 @customElement('obc-rot-indicator')
 export class ObcRotIndicator extends LitElement {
+  /**
+   * Measured rate of turn in degrees per minute (positive = starboard).
+   *
+   * Drives the spinner animation via `(rateOfTurnDegreesPerMinute / 360) *
+   * rotDotAnimationFactor` rotations per minute. When `undefined` the legacy
+   * `rotationsPerMinute` value is used instead.
+   */
+  @property({type: Number}) rateOfTurnDegreesPerMinute: number | undefined;
+
+  /**
+   * Visual amplification applied to the spinning dot animation. Default `18`
+   * keeps the legacy visual feel (≈1 rpm at 20°/min). Has no effect when
+   * the legacy `rotationsPerMinute` API is used.
+   */
+  @property({type: Number}) rotDotAnimationFactor: number = 18;
+
+  /**
+   * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally
+   * `rotDotAnimationFactor`) instead. Takes effect only when
+   * `rateOfTurnDegreesPerMinute` is `undefined`.
+   */
   @property({type: Number})
   rotationsPerMinute = 0;
+
+  private get _effectiveRpm(): number {
+    if (this.rateOfTurnDegreesPerMinute != null) {
+      return (
+        (this.rateOfTurnDegreesPerMinute / 360) * this.rotDotAnimationFactor
+      );
+    }
+    return this.rotationsPerMinute;
+  }
 
   protected override updated(_changedProperties: PropertyValues): void {
     super.updated(_changedProperties);
     if (
-      _changedProperties.has('rotationsPerMinute') &&
+      (_changedProperties.has('rotationsPerMinute') ||
+        _changedProperties.has('rateOfTurnDegreesPerMinute') ||
+        _changedProperties.has('rotDotAnimationFactor')) &&
       this.rateOfTurnController
     ) {
-      this.rateOfTurnController.rotationsPerMinute = this.rotationsPerMinute;
+      this.rateOfTurnController.rotationsPerMinute = this._effectiveRpm;
     }
   }
 
@@ -28,7 +60,7 @@ export class ObcRotIndicator extends LitElement {
     this.rateOfTurnController = new RateOfTurnController(
       this,
       this.rot,
-      this.rotationsPerMinute
+      this._effectiveRpm
     );
   }
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rot-sector/rot-sector.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rot-sector/rot-sector.ts
@@ -87,6 +87,33 @@ export interface GaugeRadialAdvice {
 export class ObcRotSector extends SetpointMixin(LitElement) {
   @property({type: Number}) value = 0;
   @property({type: Number}) maxValue = 100;
+
+  /**
+   * Measured rate of turn in degrees per minute (positive = starboard).
+   * Alias for `value` provided for cross-component consistency with
+   * `obc-compass`, `obc-compass-sector`, `obc-compass-flat`, and
+   * `obc-rate-of-turn`. Setting this updates `value`.
+   */
+  @property({type: Number})
+  set rateOfTurn(v: number) {
+    this.value = v;
+  }
+  get rateOfTurn(): number {
+    return this.value;
+  }
+
+  /**
+   * Maximum measured rate of turn in degrees per minute. Alias for
+   * `maxValue` provided for cross-component consistency. Setting this
+   * updates `maxValue`.
+   */
+  @property({type: Number})
+  set rateOfTurnMax(v: number) {
+    this.maxValue = v;
+  }
+  get rateOfTurnMax(): number {
+    return this.maxValue;
+  }
   @property({type: Boolean}) showLabels: boolean = false;
   /** Whether to render tickmarks inside the ring. */
   @property({type: Boolean}) tickmarksInside: boolean = false;

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch-flat/watch-flat.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch-flat/watch-flat.ts
@@ -67,19 +67,33 @@ export class ObcWatchFlat extends LitElement {
   @property({type: Boolean}) rotPortStarboard: boolean = false;
   @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_PX;
 
+  @property({type: Number}) rateOfTurnDegreesPerMinute: number | undefined;
+  @property({type: Number}) rotDotAnimationFactor: number = 18;
+
+  /**
+   * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally
+   * `rotDotAnimationFactor`) instead. Takes effect only when
+   * `rateOfTurnDegreesPerMinute` is `undefined`.
+   */
   @property({type: Number})
   set rotationsPerMinute(value: number) {
-    this._rotationsPerMinute = value;
-    if (this._rotController) {
-      this._rotController.rotationsPerMinute = value;
-    }
+    this._legacyRotationsPerMinute = value;
   }
   get rotationsPerMinute() {
-    return this._rotationsPerMinute;
+    return this._legacyRotationsPerMinute;
   }
 
-  private _rotationsPerMinute = 0;
+  private _legacyRotationsPerMinute = 0;
   private _rotController?: RateOfTurnController;
+
+  private get _effectiveRpm(): number {
+    if (this.rateOfTurnDegreesPerMinute != null) {
+      return (
+        (this.rateOfTurnDegreesPerMinute / 360) * this.rotDotAnimationFactor
+      );
+    }
+    return this._legacyRotationsPerMinute;
+  }
 
   private get totalHeight(): number {
     return this.bottomBar ? this.height + this.ticksHeight : this.height;
@@ -216,7 +230,7 @@ export class ObcWatchFlat extends LitElement {
       const direction =
         this.rotType === RotType.bar
           ? this.rotEndX - this.rotStartX
-          : this._rotationsPerMinute;
+          : this._effectiveRpm;
 
       if (direction > 0) {
         return {
@@ -285,9 +299,9 @@ export class ObcWatchFlat extends LitElement {
       : 'var(--instrument-regular-secondary-color)';
     let dotsColor = neutralDotsColor;
     if (this.rotPortStarboard) {
-      if (this._rotationsPerMinute > 0) {
+      if (this._effectiveRpm > 0) {
         dotsColor = 'var(--instrument-starboard-secondary-color)';
-      } else if (this._rotationsPerMinute < 0) {
+      } else if (this._effectiveRpm < 0) {
         dotsColor = 'var(--instrument-port-secondary-color)';
       }
     }
@@ -318,11 +332,19 @@ export class ObcWatchFlat extends LitElement {
       this._rotController = new RateOfTurnController(
         this,
         el,
-        this._rotationsPerMinute,
+        this._effectiveRpm,
         cyclePx
       );
     } else {
       this._rotController.cyclePx = cyclePx;
+    }
+
+    if (
+      changed.has('rateOfTurnDegreesPerMinute') ||
+      changed.has('rotDotAnimationFactor') ||
+      changed.has('rotationsPerMinute')
+    ) {
+      this._rotController.rotationsPerMinute = this._effectiveRpm;
     }
   }
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
@@ -173,7 +173,9 @@ const RADIAL_SETPOINT_INWARD_ADJUST = 4;
  * @property {number} rotStartAngle - Start angle of the ROT bar arc in degrees (0° = 12 o'clock, clockwise). Only used when `rotType` is `'bar'`.
  * @property {number} rotEndAngle - End angle of the ROT bar arc in degrees. The bar is hidden when the difference from `rotStartAngle` is less than 0.1°.
  * @property {Priority|undefined} rotPriority - Override priority for ROT color derivation. When set, ROT colors use this instead of the main `priority`. Useful when the ROT element has independent priority (e.g. compass per-element priority).
- * @property {number} rotationsPerMinute - Spin speed of the ROT dot ring in rotations per minute. Sign controls direction (positive = clockwise).
+ * @property {number|undefined} rateOfTurnDegreesPerMinute - Measured rate of turn in degrees per minute (the maritime/AIS convention, see ES-TRIN 2025/1 Art. 3.02 and ITU-R M.1371). Sign controls direction (positive = starboard/clockwise). When defined, this drives both the dot animation (multiplied by `rotDotAnimationFactor`) and the port/starboard direction sign.
+ * @property {number} rotDotAnimationFactor - Visual amplification factor applied only to the spinning-dot animation (not to bar extent). Default `18` keeps the legacy visual feel (≈1 rpm at 20°/min).
+ * @property {number} rotationsPerMinute - **Deprecated.** Spin speed of the ROT dot ring in rotations per minute. Sign controls direction (positive = clockwise). Use `rateOfTurnDegreesPerMinute` instead.
  * @property {ZoomToFitArcFrame|undefined} arcFrame - Pre-computed zoom-to-fit arc frame. When set, the watch skips its own `computeZoomToFitArcFrame()` call and uses these values directly. Consumer instruments (e.g. rudder, instrument-radial) should compute the frame once and pass it here to avoid redundant computation.
  */
 @customElement('obc-watch')
@@ -244,18 +246,38 @@ export class ObcWatch extends LitElement {
   @property({type: String}) rotPriority: Priority | undefined;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
   @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
+  @property({type: Number}) rateOfTurnDegreesPerMinute: number | undefined;
+  @property({type: Number}) rotDotAnimationFactor: number = 18;
+  /**
+   * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally `rotDotAnimationFactor`) instead.
+   * Kept as a backward-compatible alias; takes effect only when
+   * `rateOfTurnDegreesPerMinute` is `undefined`.
+   */
   @property({type: Number})
   set rotationsPerMinute(value: number) {
-    this._rotationsPerMinute = value;
-    if (this._rotController) {
-      this._rotController.rotationsPerMinute = value;
-    }
+    this._legacyRotationsPerMinute = value;
   }
   get rotationsPerMinute() {
-    return this._rotationsPerMinute;
+    return this._legacyRotationsPerMinute;
   }
-  private _rotationsPerMinute = 0;
+  private _legacyRotationsPerMinute = 0;
   private _rotController?: RateOfTurnController;
+
+  /**
+   * Effective rotations-per-minute for the spinning dot animation and
+   * port/starboard direction sign. Resolves to:
+   *   • `(rateOfTurnDegreesPerMinute / 360) * rotDotAnimationFactor` when the
+   *     new physical API is in use, OR
+   *   • the legacy `rotationsPerMinute` value otherwise.
+   */
+  private get _effectiveRpm(): number {
+    if (this.rateOfTurnDegreesPerMinute != null) {
+      return (
+        (this.rateOfTurnDegreesPerMinute / 360) * this.rotDotAnimationFactor
+      );
+    }
+    return this._legacyRotationsPerMinute;
+  }
 
   // @ts-expect-error TS6133: The controller ensures that the render
   // function is called on resize of the element
@@ -263,6 +285,17 @@ export class ObcWatch extends LitElement {
 
   override willUpdate(changed: PropertyValues): void {
     super.willUpdate(changed);
+
+    // Push the resolved effective RPM into the live controller whenever any
+    // of the inputs that compose it change.
+    if (
+      this._rotController &&
+      (changed.has('rateOfTurnDegreesPerMinute') ||
+        changed.has('rotDotAnimationFactor') ||
+        changed.has('rotationsPerMinute'))
+    ) {
+      this._rotController.rotationsPerMinute = this._effectiveRpm;
+    }
 
     // Detect confirm: newAngleSetpoint was defined, now undefined
     if (changed.has('newAngleSetpoint') && this.animateSetpoint) {
@@ -298,7 +331,7 @@ export class ObcWatch extends LitElement {
       this._rotController = new RateOfTurnController(
         this,
         el,
-        this._rotationsPerMinute
+        this._effectiveRpm
       );
     }
   }
@@ -805,7 +838,7 @@ export class ObcWatch extends LitElement {
           (((this.rotEndAngle - this.rotStartAngle) % 360) + 360) % 360;
         direction = cwSpan <= 180 ? cwSpan : cwSpan - 360;
       } else {
-        direction = this._rotationsPerMinute;
+        direction = this._effectiveRpm;
       }
 
       if (direction > 0) {
@@ -880,9 +913,9 @@ export class ObcWatch extends LitElement {
       ? 'var(--instrument-enhanced-secondary-color)'
       : 'var(--instrument-regular-secondary-color)';
     if (this.rotPortStarboard) {
-      if (this._rotationsPerMinute > 0) {
+      if (this._effectiveRpm > 0) {
         dotsColor = 'var(--instrument-starboard-secondary-color)';
-      } else if (this._rotationsPerMinute < 0) {
+      } else if (this._effectiveRpm < 0) {
         dotsColor = 'var(--instrument-port-secondary-color)';
       }
     }


### PR DESCRIPTION
… and deprecate `rotationsPerMinute`

Closes #802

Replaces the animation-centric `rotationsPerMinute` with a physically meaningful `rateOfTurnDegreesPerMinute` API across all ROT-bearing components, aligning with the maritime / AIS convention (ES-TRIN 2025/1 Art. 3.02 and ITU-R M.1371). A new `rotDotAnimationFactor` property decouples the dot animation speed from the physical value, so the spinning dots remain expressive without corrupting the unit on the public API. Bar extent is driven by the physical value only — gain is not applied — so bars/needles remain a quantitative representation while dots stay a qualitative animated aid.

| | Before (legacy stories) | After (new stories) |
|---|---|---|
| **Property used** | `rotationsPerMinute` | `rateOfTurnDegreesPerMinute` + `rotDotAnimationFactor` |
| **Value you pass** | `5` (rpm, animation-centric) | `20` (°/min, real-world) |
| **Bar extent** | `rotationsPerMinute / rotMaxValue` | `rateOfTurnDegreesPerMinute / rotMaxValue` |
| **Dot speed** | Locked to the same value as bar | Independent via `rotDotAnimationFactor` |
| **Default `rotMaxValue`** | Was `10` (rpm) | Now `60` (°/min) — matches ES-TRIN 2025/1 |

## New API

Added to `obc-watch`, `obc-watch-flat`, `obc-rate-of-turn`, `obc-compass`, `obc-compass-sector`, `obc-compass-flat`, and `obc-rot-indicator`:

* `rateOfTurnDegreesPerMinute: number | undefined` — measured ROT in degrees per minute; sign controls direction (positive = starboard).
* `rotDotAnimationFactor: number = 18` — visual amplification applied to the spinning-dot animation only. Default `18` keeps the prior visual feel (≈1 rpm at 20°/min). No effect on bar extent.

Effective spinner RPM is computed as
`(rateOfTurnDegreesPerMinute / 360) * rotDotAnimationFactor`. When the new property is `undefined`, the legacy `rotationsPerMinute` value is used as fallback so existing consumers keep their visuals during the deprecation window.

Added to `obc-rot-sector` for cross-component consistency:

* `rateOfTurn` — alias for `value` (deg/min).
* `rateOfTurnMax` — alias for `maxValue` (deg/min).

## Deprecations

* `rotationsPerMinute` on every component above is marked `@deprecated` in JSDoc but remains fully functional. It will be removed in the next major release. Prefer `rateOfTurnDegreesPerMinute`.

## Implementation notes

* `RateOfTurnController` is unchanged — it stays rpm-based. The conversion happens in `obc-watch` / `obc-watch-flat` before values are pushed to the controller.
* Bar-extent calculations in `compass.ts`, `compass-sector.ts`, and `compass-flat.ts` were rewritten to use the resolved deg/min value, divided by `rotMaxValue` and scaled by `rotArcExtent`.
* Stories gained new `rateOfTurnDegreesPerMinute` / `rotDotAnimationFactor` controls plus one `Rate of Turn Degrees Per Minute` demo per component (tagged `skip-test` to avoid extra visual baselines). Existing legacy stories are preserved unchanged to verify the fallback path.
* `custom-elements.json` regenerated.

## Follow-ups (intentionally out of scope)

* No `console.warn` deprecation hint — JSDoc `@deprecated` is the signal; runtime warnings would create log noise for current consumers.
* Renaming `rotMaxValue` itself (kept for now to limit churn).
* Vico Fischer's full "decouple dots from ROT entirely" UX direction (issue #802 last comment) — preserved for a future iteration; this change keeps the existing expressive dot animation while making the unit physically meaningful.
* Removing the deprecated `rotationsPerMinute` property — next major.
* Framework wrappers (`-react`, `-vue`, `-ng`, `-svelte`) regenerate automatically from `custom-elements.json`.

BREAKING CHANGE: `rotMaxValue` on `obc-compass`, `obc-compass-sector`, and `obc-compass-flat` is now interpreted in **degrees per minute** instead of rotations per minute. The default value was bumped from `10` to `60` (per ES-TRIN 2025/1 Art. 3.02) to match the new unit. Consumers that set `rotMaxValue` explicitly must convert their value: a previous `rotMaxValue=10` (rpm) corresponds to `rotMaxValue=3600` (°/min), but in practice the typical operating range is `30`–`90` °/min.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Measured rate-of-turn input (degrees/min) and a visual-only dot amplification control (rotDotAnimationFactor, default 18) added across compass, sector, watch, watch-flat, rot-indicator, and rate-of-turn instruments; sector also gained rateOfTurn/rateOfTurnMax aliases.  
* **Deprecation**
  * Legacy rotations-per-minute input marked deprecated and kept only as a fallback.  
* **Behavior**
  * rotMaxValue semantics standardized as a degrees-per-minute reference (default 60).  
* **Documentation**
  * Storybook controls and new example stories updated to showcase the new API and dot tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->