### PR TITLE
fix(watch): guard roundedArch to prevent NaN SVG paths

### DIFF
--- a/packages/openbridge-webcomponents/src/svghelpers/roundedArch.ts
+++ b/packages/openbridge-webcomponents/src/svghelpers/roundedArch.ts
@@ -26,8 +26,15 @@ export function roundedArch({
   const y2 = -Math.cos(a2) * r;
   const roundRadius = 8;
 
+  // Guard against degenerate radii: corner rounding requires the ring
+  // radius to be at least `roundRadius`, otherwise Math.asin(roundRadius/r)
+  // returns NaN and produces an invalid SVG path. Fall back to a square cut
+  // in that case (notably when r === 0 for pie-slice clip paths).
+  const safeRoundOutsideCut = roundOutsideCut && R >= roundRadius;
+  const safeRoundInsideCut = roundInsideCut && r >= roundRadius;
+
   let svgPath = '';
-  if (roundOutsideCut) {
+  if (safeRoundOutsideCut) {
     const roundDeltaAngle = Math.asin(roundRadius / R);
     const largeArcFlag =
       a2 - roundDeltaAngle - (a1 + roundDeltaAngle) <= Math.PI ? 0 : 1;
@@ -50,7 +57,7 @@ export function roundedArch({
     svgPath += `M ${X1} ${Y1} A ${R} ${R} 1 ${largeArcFlag} 1 ${X2} ${Y2}`;
   }
 
-  if (roundInsideCut) {
+  if (safeRoundInsideCut) {
     const roundDeltaAngle = Math.asin(roundRadius / r);
     const largeArcFlag =
       a2 - roundDeltaAngle - (a1 + roundDeltaAngle) <= Math.PI ? 0 : 1;


### PR DESCRIPTION
The `rotClip` clipPath in obc-watch calls roundedArch with `r: 0` (a pie slice from the centre) while still forwarding `roundInsideCut: true` from the area config. Inside roundedArch, `Math.asin(8 / r)` then evaluates to NaN, producing invalid `d` attributes such as
"A 8 8 1 0 1 NaN NaN" — visible as console errors in Chromium-based browsers (Firefox is more lenient and silently ignores them).

Fix it at the helper level: when the ring radius is smaller than the 8 px corner radius, fall back to a square cut. This is a no-op for every existing valid caller (real ring radii are >= 88) and protects future callers from the same footgun.

Closes #819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed SVG rendering issues with rounded corner arches that could produce invalid rendering parameters in certain edge cases. The component now automatically detects unsafe conditions and falls back to standard corner rendering, ensuring stable and consistent visual output across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->