### PR TITLE
fix(setpoint)!: unify deadband boundary and extract config mixins

### DIFF
--- a/.github/instructions/setpoint.instructions.md
+++ b/.github/instructions/setpoint.instructions.md
@@ -328,6 +328,73 @@ computeAtSetpoint({
 
 ---
 
+## `isAtZero()` — Zero-Snap Helper
+
+Companion to `computeAtSetpoint`, used to decide whether a setpoint that is
+*near zero* should snap to the visual "at zero" state (typically rendered
+in muted colors). Defined in `setpoint.ts`:
+
+```ts
+isAtZero(value: number | undefined, deadband: number): boolean
+```
+
+**Rules:**
+
+- Returns `false` if `value` is `undefined` or `NaN`.
+- Returns `false` if `deadband` is not finite.
+- Otherwise returns `Math.abs(value) < deadband` — note **strict less-than**.
+
+### `<` vs `<=` distinction
+
+| Helper               | Comparison | Rationale                                                                                |
+| -------------------- | ---------- | ---------------------------------------------------------------------------------------- |
+| `computeAtSetpoint`  | `<=`       | Inclusive — the setpoint marker should "lock" at the boundary as soon as it is reached. |
+| `isAtZero`           | `<`        | Exclusive — a value exactly equal to the deadband is still considered nonzero.           |
+
+**Both helpers MUST be used instead of any local `Math.abs(...) < deadband`
+math.** A grep for `Math.abs.*setpoint` outside `src/svghelpers/` should
+return zero matches.
+
+---
+
+## Single Source of Truth
+
+All deadband / zero-snap math for setpoints lives in `src/svghelpers/setpoint.ts`:
+
+- **`computeAtSetpoint(config)`** — for "is `value` at `setpoint`?"
+- **`isAtZero(value, deadband)`** — for "is `value` at zero?"
+
+**Forbidden:** Defining a local `atSetpointCalc()`, `atSetpointFn()`, or
+inline `Math.abs(value - setpoint) <= deadband` anywhere outside
+`src/svghelpers/`. If the canonical helpers don't cover your use case, add
+a parameter to them rather than forking the math.
+
+---
+
+## Companion Mixins
+
+The setpoint mixin sits next to two other reactive-property cluster mixins
+that follow the same Lit-mixin pattern. Compose them by chaining:
+
+```ts
+class ObcGaugeRadial extends TickmarkIntervalMixin(
+  VisualConfigMixin(SetpointMixin(LitElement)),
+  {defaultPrimary: 50, defaultSecondary: 10}
+) { … }
+```
+
+| Mixin                       | File                                          | Adds (5 / 5 / 3 props)                                                                  |
+| --------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `SetpointMixin`             | `svghelpers/setpoint-mixin.ts`                | `setpoint`, `newSetpoint`, `atSetpoint`, `touching`, `autoAtSetpoint`, …                |
+| `VisualConfigMixin`         | `svghelpers/visual-config-mixin.ts`           | `state`, `priority`, `tickmarkStyle`, `showLabels`, `tickmarksInside`                   |
+| `TickmarkIntervalMixin`     | `svghelpers/tickmark-interval-mixin.ts`       | `primaryTickmarkInterval`, `secondaryTickmarkInterval`, `tertiaryTickmarkInterval`      |
+
+Use `TickmarkIntervalMixin(superClass, {defaultPrimary, defaultSecondary, defaultTertiary})`
+to pass per-component default cadences. All three intervals always exist;
+omit a `default*` to leave that tier `undefined` (no tickmarks rendered).
+
+---
+
 ## Stories
 
 Interactive stories for the setpoint system live in `building-blocks/setpoint/setpoint.stories.ts`:

--- a/packages/openbridge-webcomponents/src/building-blocks/external-scale/external-scale.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/external-scale/external-scale.ts
@@ -26,6 +26,7 @@ import {
   generateSetpointId,
   getSetpointOutwardOffset,
   computeAtSetpoint,
+  isAtZero,
   SETPOINT_ANIMATION_CSS_VAR,
   SETPOINT_ANIMATION_DURATION_DEFAULT,
 } from '../../svghelpers/setpoint.js';
@@ -894,9 +895,10 @@ function deriveSetpointVisualState(
 
   if (isAt) {
     // Check if setpoint is at zero (using setpointAtZeroDeadband)
-    const setpointAtZero =
-      config.setpoint !== undefined &&
-      Math.abs(config.setpoint) < config.setpointAtZeroDeadband;
+    const setpointAtZero = isAtZero(
+      config.setpoint,
+      config.setpointAtZeroDeadband
+    );
 
     if (setpointAtZero) {
       return SetpointVisualState.equalZero;
@@ -2288,8 +2290,7 @@ function renderSingleSetpoint(
   const stateOffset = getSetpointOutwardOffset(visualState);
 
   // Check if setpoint snaps to zero
-  const setpointAtZero =
-    Math.abs(setpointValue) < config.setpointAtZeroDeadband;
+  const setpointAtZero = isAtZero(setpointValue, config.setpointAtZeroDeadband);
 
   // Main axis position (where the marker sits along the scale)
   // Always use valueToMainAxis — even for zero-snap, since coordinate 0

--- a/packages/openbridge-webcomponents/src/building-blocks/instrument-linear/instrument-linear.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/instrument-linear/instrument-linear.ts
@@ -3,6 +3,7 @@ import {InstrumentState, Priority} from '../../navigation-instruments/types.js';
 
 import {LinearAdviceRaw} from '../../navigation-instruments/thruster/advice.js';
 import {renderAdvice} from './advice.js';
+import {computeAtSetpoint} from '../../svghelpers/setpoint.js';
 
 export function atSetpoint(
   thrust: number,
@@ -14,15 +15,14 @@ export function atSetpoint(
     atSetpoint: boolean;
   }
 ): boolean {
-  if (options.touching) {
-    return false;
-  }
-
-  if (options.autoAtSetpoint && setpoint !== undefined) {
-    return Math.abs(thrust - setpoint) < options.autoAtSetpointDeadband;
-  }
-
-  return options.atSetpoint;
+  return computeAtSetpoint({
+    value: thrust,
+    setpoint,
+    touching: options.touching,
+    auto: options.autoAtSetpoint,
+    deadband: options.autoAtSetpointDeadband,
+    atSetpointManual: options.atSetpoint,
+  });
 }
 
 /**

--- a/packages/openbridge-webcomponents/src/building-blocks/instrument-radial/instrument-radial.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/instrument-radial/instrument-radial.ts
@@ -9,9 +9,10 @@ import {
 import {WatchCircleType} from '../../navigation-instruments/watch/watch.js';
 import {Tickmark} from '../../navigation-instruments/watch/tickmark.js';
 import {TickmarkType} from '../../navigation-instruments/watch/tickmark.js';
-import {TickmarkStyle} from '../../navigation-instruments/watch/tickmark.js';
 import {InstrumentState, Priority} from '../../navigation-instruments/types.js';
 import {SetpointMixin} from '../../svghelpers/setpoint-mixin.js';
+import {VisualConfigMixin} from '../../svghelpers/visual-config-mixin.js';
+import {TickmarkIntervalMixin} from '../../svghelpers/tickmark-interval-mixin.js';
 import {
   OUTER_RING_RADIUS,
   innerRingRadiusFor,
@@ -56,13 +57,17 @@ function strongerTickmarkType(
 }
 
 @customElement('obc-instrument-radial')
-export class ObcInstrumentRadial extends SetpointMixin(LitElement) {
+export class ObcInstrumentRadial extends TickmarkIntervalMixin(
+  VisualConfigMixin(SetpointMixin(LitElement)),
+  {defaultPrimary: 50, defaultSecondary: 10}
+) {
   // setpoint, newSetpoint, atSetpoint, touching, autoAtSetpoint,
   // autoAtSetpointDeadband, setpointAtZeroDeadband, setpointOverride
   // — all inherited from SetpointMixin
-
-  @property({type: String}) state: InstrumentState = InstrumentState.active;
-  @property({type: String}) priority: Priority = Priority.regular;
+  // state, priority, tickmarkStyle, showLabels, tickmarksInside
+  // — all inherited from VisualConfigMixin
+  // primaryTickmarkInterval, secondaryTickmarkInterval, tertiaryTickmarkInterval
+  // — all inherited from TickmarkIntervalMixin
 
   @property({type: Number}) value = 0;
   @property({type: Number}) maxValue = 100;
@@ -70,30 +75,10 @@ export class ObcInstrumentRadial extends SetpointMixin(LitElement) {
   @property({attribute: false}) getAngle!: (v: number) => number;
   @property({type: String}) needleColor: string | undefined;
   @property({type: String}) barColor: string | undefined;
-  @property({type: Boolean}) showLabels: boolean = false;
-  /**
-   * Interval for primary tickmarks in value units.
-   * When undefined or <= 0, no primary tickmarks are shown.
-   */
-  @property({type: Number}) primaryTickmarkInterval: number | undefined = 50;
-  /**
-   * Interval for secondary tickmarks in value units.
-   * When undefined or <= 0, no secondary tickmarks are shown.
-   */
-  @property({type: Number}) secondaryTickmarkInterval: number | undefined = 10;
-  /**
-   * Interval for tertiary tickmarks in value units.
-   * When undefined or <= 0, no tertiary tickmarks are shown.
-   */
-  @property({type: Number}) tertiaryTickmarkInterval: number | undefined =
-    undefined;
   @property({type: String}) type: ObcGaugeRadialType =
     ObcGaugeRadialType.filled;
   @property({type: String}) needleType: ObcGaugeRadialType =
     ObcGaugeRadialType.filled;
-  @property({type: Boolean}) tickmarksInside: boolean = false;
-  @property({type: String}) tickmarkStyle: TickmarkStyle =
-    TickmarkStyle.regular;
   @property({type: Array, attribute: false}) advices: GaugeRadialAdvice[] = [];
   @property({type: Number}) clipTop: number = 0; // in percent of height
   @property({type: Number}) clipBottom: number = 0; // in percent of height

--- a/packages/openbridge-webcomponents/src/navigation-instruments/azimuth-thruster/azimuth-thruster.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/azimuth-thruster/azimuth-thruster.ts
@@ -1,14 +1,15 @@
 import {html, LitElement, unsafeCSS} from 'lit';
 import {property} from 'lit/decorators.js';
 import type {PropertyValues} from 'lit';
-import {InstrumentState, Priority} from '../types.js';
 import {SetpointBundle} from '../../svghelpers/setpoint-bundle.js';
+import {VisualConfigMixin} from '../../svghelpers/visual-config-mixin.js';
+import {TickmarkIntervalMixin} from '../../svghelpers/tickmark-interval-mixin.js';
 import {thruster} from '../thruster/thruster.js';
 import '../watch/watch.js';
 import componentStyle from './azimuth-thruster.css?inline';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {AdviceState, AngleAdvice, AngleAdviceRaw} from '../watch/advice.js';
-import {Tickmark, TickmarkStyle, TickmarkType} from '../watch/tickmark.js';
+import {Tickmark, TickmarkType} from '../watch/tickmark.js';
 import {LinearAdvice} from '../thruster/advice.js';
 import {PropellerType} from '../thruster/propeller.js';
 import {customElement} from '../../decorator.js';
@@ -23,7 +24,10 @@ function mapAngle0to360(angle: number): number {
 }
 
 @customElement('obc-azimuth-thruster')
-export class ObcAzimuthThruster extends LitElement {
+export class ObcAzimuthThruster extends TickmarkIntervalMixin(
+  VisualConfigMixin(LitElement),
+  {defaultPrimary: 90}
+) {
   private _thrustSetpointId = `azimuth-thrust-sp-${Math.random().toString(36).slice(2, 9)}`;
 
   @property({type: Number}) angle = 0;
@@ -38,26 +42,6 @@ export class ObcAzimuthThruster extends LitElement {
     true;
   @property({type: Number}) autoAtAngleSetpointDeadband: number = 2;
   @property({type: Boolean}) animateSetpoint: boolean = false;
-  /**
-   * Interval (in degrees) for primary tickmarks.
-   * When undefined or <= 0, no primary tickmarks are shown (only the zero line).
-   * Default 90 gives ticks at 0°, 90°, 180°, 270°.
-   */
-  @property({type: Number}) primaryTickmarkInterval: number | undefined = 90;
-  /**
-   * Interval (in degrees) for secondary tickmarks.
-   * When undefined or <= 0, no secondary tickmarks are shown.
-   */
-  @property({type: Number}) secondaryTickmarkInterval: number | undefined =
-    undefined;
-  /**
-   * Interval (in degrees) for tertiary tickmarks.
-   * When undefined or <= 0, no tertiary tickmarks are shown.
-   */
-  @property({type: Number}) tertiaryTickmarkInterval: number | undefined =
-    undefined;
-  @property({type: Boolean}) showLabels: boolean = false;
-  @property({type: Boolean}) tickmarksInside: boolean = false;
   @property({type: Number}) thrust = 0;
   @property({type: Number}) thrustSetpoint: number | undefined;
   @property({type: Number}) newThrustSetpoint: number | undefined;
@@ -68,8 +52,6 @@ export class ObcAzimuthThruster extends LitElement {
   @property({type: Boolean, attribute: false}) autoAtThrustSetpoint: boolean =
     true;
   @property({type: Number}) autoAtThrustSetpointDeadband: number = 1;
-  @property({type: String}) state: InstrumentState = InstrumentState.active;
-  @property({type: String}) priority: Priority = Priority.regular;
 
   private _angleSp = new SetpointBundle({
     angularWraparound: true,
@@ -114,8 +96,6 @@ export class ObcAzimuthThruster extends LitElement {
   @property({type: Boolean}) singleDirection: boolean = false;
   @property({type: String}) topPropeller: PropellerType = PropellerType.none;
   @property({type: String}) bottomPropeller: PropellerType = PropellerType.none;
-  @property({type: String}) tickmarkStyle: TickmarkStyle =
-    TickmarkStyle.regular;
   @property({type: Boolean}) starboardPortIndicator: boolean = false;
 
   private get angleAdviceRaw(): AngleAdviceRaw[] {

--- a/packages/openbridge-webcomponents/src/navigation-instruments/gauge-radial/gauge-radial.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/gauge-radial/gauge-radial.ts
@@ -2,10 +2,10 @@ import {LitElement, html} from 'lit';
 import {customElement} from '../../decorator.js';
 import {property} from 'lit/decorators.js';
 import {AdviceType} from '../watch/advice.js';
-import {InstrumentState, Priority} from '../types.js';
 import {SetpointMixin} from '../../svghelpers/setpoint-mixin.js';
+import {VisualConfigMixin} from '../../svghelpers/visual-config-mixin.js';
+import {TickmarkIntervalMixin} from '../../svghelpers/tickmark-interval-mixin.js';
 import '../../building-blocks/instrument-radial/instrument-radial.js';
-import {TickmarkStyle} from '../watch/tickmark.js';
 
 export enum ObcGaugeRadialType {
   filled = 'filled',
@@ -78,26 +78,15 @@ export interface GaugeRadialAdvice {
  * @typedef {import('./gauge-radial.js').GaugeRadialAdvice} GaugeRadialAdvice
  */
 @customElement('obc-gauge-radial')
-export class ObcGaugeRadial extends SetpointMixin(LitElement) {
+export class ObcGaugeRadial extends TickmarkIntervalMixin(
+  VisualConfigMixin(SetpointMixin(LitElement)),
+  {defaultPrimary: 50, defaultSecondary: 10}
+) {
   @property({type: Number}) value = 0;
   @property({type: Number}) maxValue = 100;
   @property({type: Number}) minValue = 0;
-  @property({type: Boolean}) showLabels: boolean = false;
-  @property({type: Number}) primaryTickmarkInterval = 50;
-  @property({type: Number}) secondaryTickmarkInterval = 10;
-  /**
-   * Interval for tertiary tickmarks in value units.
-   * When undefined or <= 0, no tertiary tickmarks are shown.
-   */
-  @property({type: Number}) tertiaryTickmarkInterval: number | undefined =
-    undefined;
-  @property({type: String}) state: InstrumentState = InstrumentState.active;
-  @property({type: String}) priority: Priority = Priority.regular;
   @property({type: String}) type: ObcGaugeRadialType =
     ObcGaugeRadialType.filled;
-  @property({type: Boolean}) tickmarksInside: boolean = false;
-  @property({type: String}) tickmarkStyle: TickmarkStyle =
-    TickmarkStyle.regular;
   @property({type: Array, attribute: false}) advices: GaugeRadialAdvice[] = [];
 
   getAngle(v: number): number {

--- a/packages/openbridge-webcomponents/src/navigation-instruments/instrument-field/instrument-field.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/instrument-field/instrument-field.ts
@@ -6,6 +6,7 @@ import '../../components/button/button.js';
 import '../../icons/icon-drop-down-google.js';
 import '../../components/navigation-item/navigation-item.js';
 import {customElement} from '../../decorator.js';
+import {computeAtSetpoint} from '../../svghelpers/setpoint.js';
 
 /**
  * Enum for instrument field sizes.
@@ -118,9 +119,14 @@ export class ObcInstrumentField extends LitElement {
     const hideSetpoint =
       this.hasSetpoint &&
       this.autoHideSetpoint &&
-      this.setpoint !== undefined &&
-      this.value !== undefined &&
-      Math.abs(this.setpoint - this.value) <= this.autoHideDeadband;
+      computeAtSetpoint({
+        value: this.value,
+        setpoint: this.setpoint,
+        touching: false,
+        auto: true,
+        deadband: this.autoHideDeadband,
+        atSetpointManual: false,
+      });
 
     return html`
       <div

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rot-sector/rot-sector.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rot-sector/rot-sector.ts
@@ -4,6 +4,7 @@ import {property} from 'lit/decorators.js';
 import {AdviceType} from '../watch/advice.js';
 import {Priority} from '../types.js';
 import {SetpointMixin} from '../../svghelpers/setpoint-mixin.js';
+import {TickmarkIntervalMixin} from '../../svghelpers/tickmark-interval-mixin.js';
 import '../../building-blocks/instrument-radial/instrument-radial.js';
 import {TickmarkStyle} from '../watch/tickmark.js';
 
@@ -84,28 +85,15 @@ export interface GaugeRadialAdvice {
  * @typedef {import('./rot-sector.js').GaugeRadialAdvice} GaugeRadialAdvice
  */
 @customElement('obc-rot-sector')
-export class ObcRotSector extends SetpointMixin(LitElement) {
+export class ObcRotSector extends TickmarkIntervalMixin(
+  SetpointMixin(LitElement),
+  {defaultPrimary: 50, defaultSecondary: 10}
+) {
   @property({type: Number}) value = 0;
   @property({type: Number}) maxValue = 100;
   @property({type: Boolean}) showLabels: boolean = false;
   /** Whether to render tickmarks inside the ring. */
   @property({type: Boolean}) tickmarksInside: boolean = false;
-  /**
-   * Interval for primary tickmarks in value units.
-   * When undefined or <= 0, no primary tickmarks are shown.
-   */
-  @property({type: Number}) primaryTickmarkInterval: number | undefined = 50;
-  /**
-   * Interval for secondary tickmarks in value units.
-   * When undefined or <= 0, no secondary tickmarks are shown.
-   */
-  @property({type: Number}) secondaryTickmarkInterval: number | undefined = 10;
-  /**
-   * Interval for tertiary tickmarks in value units.
-   * When undefined or <= 0, no tertiary tickmarks are shown.
-   */
-  @property({type: Number}) tertiaryTickmarkInterval: number | undefined =
-    undefined;
   @property({type: String}) priority: Priority = Priority.regular;
   @property({type: Boolean}) portStarboard: boolean = false;
   @property({type: String}) tickmarkStyle: TickmarkStyle =

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rudder/rudder.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rudder/rudder.ts
@@ -1,7 +1,7 @@
 import {LitElement, css, html, nothing, svg} from 'lit';
 import {property} from 'lit/decorators.js';
 import '../watch/watch.js';
-import {Tickmark, TickmarkStyle, TickmarkType} from '../watch/tickmark.js';
+import {Tickmark, TickmarkType} from '../watch/tickmark.js';
 import {
   OUTER_RING_RADIUS,
   WatchCircleType,
@@ -9,6 +9,7 @@ import {
 } from '../watch/watch.js';
 import {InstrumentState, Priority} from '../types.js';
 import {SetpointMixin} from '../../svghelpers/setpoint-mixin.js';
+import {VisualConfigMixin} from '../../svghelpers/visual-config-mixin.js';
 import {AdviceState, AngleAdvice, AngleAdviceRaw} from '../watch/advice.js';
 import {customElement} from '../../decorator.js';
 import {
@@ -81,17 +82,10 @@ export enum ObcRudderVariant {
  * @element obc-rudder
  */
 @customElement('obc-rudder')
-export class ObcRudder extends SetpointMixin(LitElement) {
+export class ObcRudder extends VisualConfigMixin(SetpointMixin(LitElement)) {
   @property({type: Number}) angle = 0;
   @property({type: String}) variant: ObcRudderVariant = ObcRudderVariant.Bar;
   @property({type: Number}) maxAngle = 90;
-  @property({type: Boolean}) showLabels: boolean = false;
-  /** Whether to render tickmarks inside the ring. */
-  @property({type: Boolean}) tickmarksInside: boolean = false;
-  @property({type: String}) state: InstrumentState = InstrumentState.active;
-  @property({type: String}) priority: Priority = Priority.regular;
-  @property({type: String}) tickmarkStyle: TickmarkStyle =
-    TickmarkStyle.regular;
   @property({type: Array, attribute: false}) advices: AngleAdvice[] = [];
   @property({type: Boolean}) zoomToFitArc: boolean = false;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/thruster/thruster.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/thruster/thruster.ts
@@ -8,8 +8,10 @@ import {singleSidedTickmark} from './tickmark.js';
 import {PropellerType, bottomPropeller, topPropeller} from './propeller.js';
 import {SetpointMixin} from '../../svghelpers/setpoint-mixin.js';
 import {
+  computeAtSetpoint,
   drawSetpointMarker,
   getSetpointOutwardOffset,
+  isAtZero,
   SetpointColorMode,
   SetpointVisualState,
   SETPOINT_ANIMATION_CSS_VAR,
@@ -373,8 +375,7 @@ export function renderThrusterSetpoint(
   setpointValue: number,
   config: ThrusterSetpointConfig
 ): SVGTemplateResult {
-  const setpointAtZero =
-    Math.abs(setpointValue) < config.setpointAtZeroDeadband;
+  const setpointAtZero = isAtZero(setpointValue, config.setpointAtZeroDeadband);
   const hasNewSetpoint = config.newSetpoint !== undefined;
   const hasDepartingNewSetpoint = config.departingNewSetpoint !== undefined;
   const animate = config.animateSetpoint === true;
@@ -451,7 +452,7 @@ export function renderThrusterSetpoint(
     const newValue = isActive
       ? config.newSetpoint!
       : config.departingNewSetpoint!;
-    const newAtZero = Math.abs(newValue) < config.setpointAtZeroDeadband;
+    const newAtZero = isAtZero(newValue, config.setpointAtZeroDeadband);
     const newY = thrusterSetpointY(height, newValue, newAtZero);
     const focusOffset = getSetpointOutwardOffset(SetpointVisualState.focus);
     const newTipX = baseX + focusOffset - THRUSTER_SETPOINT_INWARD_ADJUST;
@@ -556,6 +557,17 @@ export function setpointSvg(
   `;
 }
 
+/**
+ * Thin adapter around the canonical `computeAtSetpoint()` from
+ * `svghelpers/setpoint.ts`, preserving the legacy positional signature used
+ * by `thruster()` and `<obc-main-engine>`.
+ *
+ * Behaviorally identical to the canonical function: inclusive deadband
+ * (`distance <= deadband`), `touching` short-circuit, and `Number.isFinite`
+ * guard on the deadband. The previous local implementation used `<` instead
+ * of `<=`, so a value exactly at the deadband boundary now correctly reports
+ * as "at setpoint" — matching every other instrument.
+ */
 export function atSetpoint(
   thrust: number,
   setpoint: number | undefined,
@@ -566,15 +578,14 @@ export function atSetpoint(
     atSetpoint: boolean;
   }
 ): boolean {
-  if (options.touching) {
-    return false;
-  }
-
-  if (options.autoAtSetpoint && setpoint !== undefined) {
-    return Math.abs(thrust - setpoint) < options.autoAtSetpointDeadband;
-  }
-
-  return options.atSetpoint;
+  return computeAtSetpoint({
+    value: thrust,
+    setpoint,
+    touching: options.touching,
+    auto: options.autoAtSetpoint,
+    deadband: options.autoAtSetpointDeadband,
+    atSetpointManual: options.atSetpoint,
+  });
 }
 
 export function thruster(
@@ -630,8 +641,10 @@ export function thruster(
     centerLine = svg`<rect x=${x} y="-2" width=${width} height="4" stroke-width="1" fill=${tc.zeroLineColor} stroke=${tc.zeroLineColor} vector-effect="non-scaling-stroke"/>`;
   }
 
-  const setpointAtZero =
-    Math.abs(setpoint || 0) < options.setpointAtZeroDeadband;
+  const setpointAtZero = isAtZero(
+    setpoint ?? 0,
+    options.setpointAtZeroDeadband
+  );
 
   const {topAdvices, bottomAdvices} = convertThrustAdvices(
     options.advices,

--- a/packages/openbridge-webcomponents/src/svghelpers/setpoint.ts
+++ b/packages/openbridge-webcomponents/src/svghelpers/setpoint.ts
@@ -820,9 +820,7 @@ export function deriveRadialSetpointConfig(
   }
 
   // Auto-derive atZero from angleSetpoint and deadband
-  const atZero =
-    angleSetpoint !== undefined &&
-    Math.abs(angleSetpoint) < setpointAtZeroDeadband;
+  const atZero = isAtZero(angleSetpoint, setpointAtZeroDeadband);
 
   // For non-disabled states:
   // - atSetpoint + atZero triggers equalZero visual state (80% size)
@@ -979,4 +977,22 @@ export function computeAtSetpoint(config: ComputeAtSetpointConfig): boolean {
   }
 
   return atSetpointManual;
+}
+
+/**
+ * Whether `value` is within the zero-snap deadband (i.e. should render in
+ * the `equalZero` visual state).
+ *
+ * **Note the deliberate boundary semantics:** zero-snap uses **strict less
+ * than (`<`)**, while {@link computeAtSetpoint}'s deadband uses **inclusive
+ * (`<=`)**. The two checks serve different concerns — `isAtZero` decides
+ * whether the setpoint marker shrinks to its 80% "equalZero" size, while
+ * `computeAtSetpoint` decides whether the value has reached the target.
+ *
+ * Returns `false` for `undefined`, `NaN`, or non-finite `deadband`.
+ */
+export function isAtZero(value: number | undefined, deadband: number): boolean {
+  if (value === undefined || !Number.isFinite(value)) return false;
+  if (!Number.isFinite(deadband)) return false;
+  return Math.abs(value) < deadband;
 }

--- a/packages/openbridge-webcomponents/src/svghelpers/tickmark-interval-mixin.ts
+++ b/packages/openbridge-webcomponents/src/svghelpers/tickmark-interval-mixin.ts
@@ -1,0 +1,112 @@
+/**
+ * Tickmark Interval Mixin for Lit Elements
+ *
+ * A Lit mixin (https://lit.dev/docs/composition/mixins/) that adds the
+ * three `*TickmarkInterval` reactive properties (`primary`, `secondary`,
+ * `tertiary`) shared by all instruments and bars that render scaled
+ * tickmarks. Eliminates the copy-paste of three identical `@property()`
+ * declarations across 9+ components.
+ *
+ * ## What the mixin provides
+ *
+ * | Property                     | Type                  | Default           | Description                                            |
+ * |------------------------------|-----------------------|-------------------|--------------------------------------------------------|
+ * | `primaryTickmarkInterval`    | `number \| undefined` | from options      | Interval (in value units) between primary tickmarks   |
+ * | `secondaryTickmarkInterval`  | `number \| undefined` | from options      | Interval between secondary tickmarks                  |
+ * | `tertiaryTickmarkInterval`   | `number \| undefined` | from options      | Interval between tertiary tickmarks                   |
+ *
+ * In all cases, `undefined` or a non-positive value (`<= 0`) means "do
+ * not render that tier of tickmarks".
+ *
+ * ## Per-component defaults
+ *
+ * Different instruments use different default cadences (e.g. `50/10` for
+ * a 0–100 gauge, `90/undefined` for a compass-style 360° dial). Pass the
+ * defaults via the options object:
+ *
+ * ```ts
+ * class ObcGaugeRadial extends TickmarkIntervalMixin(LitElement, {
+ *   defaultPrimary: 50,
+ *   defaultSecondary: 10,
+ * }) { … }
+ *
+ * class ObcAzimuthThruster extends TickmarkIntervalMixin(LitElement, {
+ *   defaultPrimary: 90,
+ * }) { … }
+ * ```
+ *
+ * Omit a `default*` to leave the corresponding interval `undefined` (no
+ * tickmarks rendered for that tier by default).
+ *
+ * ## Composition
+ *
+ * Composes cleanly with {@link SetpointMixin} and {@link VisualConfigMixin}:
+ *
+ * ```ts
+ * class ObcGaugeRadial extends TickmarkIntervalMixin(
+ *   VisualConfigMixin(SetpointMixin(LitElement)),
+ *   {defaultPrimary: 50, defaultSecondary: 10}
+ * ) { … }
+ * ```
+ */
+
+import {LitElement} from 'lit';
+import {property} from 'lit/decorators.js';
+
+/** Constructor type helper for mixins. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = object> = new (...args: any[]) => T;
+
+/** Options for {@link TickmarkIntervalMixin}. */
+export interface TickmarkIntervalMixinOptions {
+  /** Default value for `primaryTickmarkInterval`. Omit for `undefined`. */
+  defaultPrimary?: number;
+  /** Default value for `secondaryTickmarkInterval`. Omit for `undefined`. */
+  defaultSecondary?: number;
+  /** Default value for `tertiaryTickmarkInterval`. Omit for `undefined`. */
+  defaultTertiary?: number;
+}
+
+/** Interface describing the properties added by {@link TickmarkIntervalMixin}. */
+export declare class TickmarkIntervalMixinInterface {
+  /**
+   * Interval (in value units) between primary tickmarks. When `undefined`
+   * or `<= 0`, no primary tickmarks are rendered.
+   */
+  primaryTickmarkInterval: number | undefined;
+  /**
+   * Interval (in value units) between secondary tickmarks. When `undefined`
+   * or `<= 0`, no secondary tickmarks are rendered.
+   */
+  secondaryTickmarkInterval: number | undefined;
+  /**
+   * Interval (in value units) between tertiary tickmarks. When `undefined`
+   * or `<= 0`, no tertiary tickmarks are rendered.
+   */
+  tertiaryTickmarkInterval: number | undefined;
+}
+
+/**
+ * Lit mixin that adds the tickmark-interval triplet to a `LitElement`.
+ *
+ * @param superClass The class to extend.
+ * @param options    Per-component defaults for the three intervals.
+ */
+export function TickmarkIntervalMixin<T extends Constructor<LitElement>>(
+  superClass: T,
+  options?: TickmarkIntervalMixinOptions
+) {
+  const {defaultPrimary, defaultSecondary, defaultTertiary} = options ?? {};
+
+  class TickmarkIntervalMixinClass extends superClass {
+    @property({type: Number}) primaryTickmarkInterval: number | undefined =
+      defaultPrimary;
+    @property({type: Number}) secondaryTickmarkInterval: number | undefined =
+      defaultSecondary;
+    @property({type: Number}) tertiaryTickmarkInterval: number | undefined =
+      defaultTertiary;
+  }
+
+  return TickmarkIntervalMixinClass as Constructor<TickmarkIntervalMixinInterface> &
+    T;
+}

--- a/packages/openbridge-webcomponents/src/svghelpers/visual-config-mixin.ts
+++ b/packages/openbridge-webcomponents/src/svghelpers/visual-config-mixin.ts
@@ -1,0 +1,83 @@
+/**
+ * Visual Config Mixin for Lit Elements
+ *
+ * A Lit mixin (https://lit.dev/docs/composition/mixins/) that adds the
+ * radial-instrument **visual configuration** property cluster to any
+ * `LitElement`. Eliminates the copy-paste of 5 `@property()` declarations
+ * across the radial navigation instruments.
+ *
+ * ## What the mixin provides
+ *
+ * | Property            | Type              | Default                  | Description                                           |
+ * |---------------------|-------------------|--------------------------|-------------------------------------------------------|
+ * | `state`             | `InstrumentState` | `InstrumentState.active` | Instrument lifecycle state (active / loading / off)   |
+ * | `priority`          | `Priority`        | `Priority.regular`       | Color priority palette (regular / enhanced)           |
+ * | `tickmarkStyle`     | `TickmarkStyle`   | `TickmarkStyle.regular`  | Tickmark color style                                  |
+ * | `showLabels`        | `boolean`         | `false`                  | Whether to render numeric / cardinal labels           |
+ * | `tickmarksInside`   | `boolean`         | `false`                  | Whether tickmarks render inside the outer ring        |
+ *
+ * All five are always declared. The defaults are no-ops for instruments
+ * that don't render a corresponding visual element, so consumers that
+ * previously omitted (for example) `state` continue to behave unchanged.
+ * Adding the properties is a purely additive, non-breaking change at the
+ * public API level.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import {VisualConfigMixin} from '../../svghelpers/visual-config-mixin.js';
+ *
+ * class MyGauge extends VisualConfigMixin(LitElement) { … }
+ *
+ * // Compose with SetpointMixin
+ * class MyGauge2 extends VisualConfigMixin(SetpointMixin(LitElement)) { … }
+ * ```
+ *
+ * @see SetpointMixin for the parallel setpoint property bundle
+ */
+
+import {LitElement} from 'lit';
+import {property} from 'lit/decorators.js';
+import {InstrumentState, Priority} from '../navigation-instruments/types.js';
+import {TickmarkStyle} from '../navigation-instruments/watch/tickmark.js';
+
+/** Constructor type helper for mixins. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = object> = new (...args: any[]) => T;
+
+/**
+ * Interface describing the properties added by {@link VisualConfigMixin}.
+ *
+ * Use this for type-checking when you need to reference the mixin's API
+ * without extending it.
+ */
+export declare class VisualConfigMixinInterface {
+  /** Instrument lifecycle state (active / loading / off). */
+  state: InstrumentState;
+  /** Color priority palette (regular / enhanced). */
+  priority: Priority;
+  /** Tickmark color style (regular / enhanced). */
+  tickmarkStyle: TickmarkStyle;
+  /** Whether to render labels (e.g. NSEW, numeric tickmarks). */
+  showLabels: boolean;
+  /** Whether to render tickmarks inside the outer ring. */
+  tickmarksInside: boolean;
+}
+
+/**
+ * Lit mixin that adds the visual-config property bundle to a `LitElement`.
+ */
+export function VisualConfigMixin<T extends Constructor<LitElement>>(
+  superClass: T
+) {
+  class VisualConfigMixinClass extends superClass {
+    @property({type: String}) state: InstrumentState = InstrumentState.active;
+    @property({type: String}) priority: Priority = Priority.regular;
+    @property({type: String}) tickmarkStyle: TickmarkStyle =
+      TickmarkStyle.regular;
+    @property({type: Boolean}) showLabels: boolean = false;
+    @property({type: Boolean}) tickmarksInside: boolean = false;
+  }
+
+  return VisualConfigMixinClass as Constructor<VisualConfigMixinInterface> & T;
+}


### PR DESCRIPTION
:warning: please do not merge it yet. I was trying to make the radial instruments more DRY by introducing similar concepts that we've done with setpoint-mixin/setpoint-bundle, but maybe it is low priority for now. Let's wait until some more important PRs get merged first, then i'll rebase it and see if still relevant.

Unify all setpoint / zero-snap math behind the canonical helpers in `svghelpers/setpoint.ts` and extract two new Lit mixins to eliminate copy-paste across the radial instruments.

BREAKING CHANGE: `atSetpoint()` in `thruster.ts` and `instrument-linear.ts` now uses an inclusive deadband (`<=`) instead of the previous strict `<`, matching every other instrument and the canonical `computeAtSetpoint()`. A value sitting exactly on the deadband boundary now reports as "at setpoint". Visual impact is limited to the single-pixel boundary case; all 305 storybook snapshots are unchanged.

Setpoint math (single source of truth)
- thruster.ts, instrument-linear.ts: `atSetpoint()` is now a thin adapter over `computeAtSetpoint()`; the local `<` boundary is gone.
- setpoint.ts: add `isAtZero(value, deadband)` companion helper with strict `<` semantics (deadband-exclusive), plus NaN / non-finite guards. Use it in `deriveRadialSetpointConfig`.
- external-scale.ts (2 sites), thruster.ts (3 sites), instrument-field.ts (1 site): replace inline `Math.abs(...) < deadband` with `isAtZero` / `computeAtSetpoint`.
- Sentinel: `grep -rIn 'Math.abs.*setpoint' src` outside `svghelpers/setpoint.ts` now returns zero matches.

New mixins (zero-behavior-change refactor)
- VisualConfigMixin (`svghelpers/visual-config-mixin.ts`): adds `state`, `priority`, `tickmarkStyle`, `showLabels`, `tickmarksInside`.
- TickmarkIntervalMixin (`svghelpers/tickmark-interval-mixin.ts`): adds `primary/secondary/tertiaryTickmarkInterval` with per-component default cadence via `{defaultPrimary, defaultSecondary, defaultTertiary}` options.
- Migrated: `instrument-radial`, `gauge-radial`, `rudder`, `azimuth-thruster`, `rot-sector` (TickmarkIntervalMixin only). Mixins compose: `TickmarkIntervalMixin(VisualConfigMixin(SetpointMixin(LitElement)), {...})`.

Docs
- `.github/instructions/setpoint.instructions.md`: document `isAtZero`, the `<` vs `<=` distinction, the single-source-of-truth rule, and the three companion mixins.

Verification
- `npm run typecheck`: clean
- `npm run lint:eslint`: clean (4 pre-existing warnings in generated locales)
- 305 / 305 storybook snapshot tests pass across `src/building-blocks` and `src/navigation-instruments`.