### PR TITLE
feat: add directional notch indicator to obc-wind

### DIFF
--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
@@ -232,6 +232,12 @@ export class ObcWatch extends LitElement {
   @property({type: Number}) clipTop: number = 0; // in percent of height
   @property({type: Number}) clipBottom: number = 0; // in percent of height
   @property({type: Number}) scaleWindIcon: number = 1;
+  @property({type: Boolean}) directionNotch: boolean = false;
+  @property({type: Number}) directionNotchAngle: number | undefined;
+  @property({type: Number}) directionNotchWidth: number = 28;
+  @property({type: Number}) directionNotchDepth: number = 16;
+  @property({type: String}) directionNotchColor: string =
+    'var(--instrument-frame-tertiary-color)';
   @property({type: Number}) rotation: number | undefined;
   @property({type: Boolean}) zoomToFitArc: boolean = false;
   @property({attribute: false}) arcFrame: ZoomToFitArcFrame | undefined;
@@ -404,6 +410,16 @@ export class ObcWatch extends LitElement {
             strokeColor: 'var(--instrument-frame-tertiary-color)',
             strokePosition: 'center',
             fillColor: 'none',
+            notch:
+              this.directionNotch && this.directionNotchAngle !== undefined
+                ? {
+                    angle: this.directionNotchAngle,
+                    width: this.directionNotchWidth,
+                    depth: this.directionNotchDepth,
+                    strokeColor: this.directionNotchColor,
+                    strokeWidth: 1,
+                  }
+                : undefined,
           })}
         `);
       } else {

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
@@ -340,7 +340,7 @@ export class ObcWatch extends LitElement {
           svg`
             <circle cx="0" cy="0" r=${r} stroke="var(--instrument-frame-secondary-color)" stroke-width=${strokeWidth} fill="none" />
             <circle cx="0" cy="0" r=${r1} stroke="var(--instrument-frame-secondary-color)" stroke-width="1" fill="none" vector-effect="non-scaling-stroke" />
-            <circle cx="0" cy="0" r=${r2} stroke="var(--instrument-frame-secondary-color)" stroke-width="1" fill="none" vector-effect="non-scaling-stroke" />
+            <circle cx="0" cy="0" r=${r2} stroke="var(--instrument-frame-secondary-color)" stroke-width="1" fill="var(--instrument-frame-primary-color)" vector-effect="non-scaling-stroke" />
         `
         );
       }

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
@@ -242,6 +242,7 @@ export class ObcWatch extends LitElement {
   @property({type: Boolean}) zoomToFitArc: boolean = false;
   @property({attribute: false}) arcFrame: ZoomToFitArcFrame | undefined;
   @property({type: Number}) tickFadeAngle: number = 0;
+  @property({type: String}) innerRingFillColor: string = 'none';
 
   @property({type: String}) rotType: RotType | undefined;
   @property({type: String}) rotPosition: RotPosition = RotPosition.innerCircle;
@@ -340,7 +341,7 @@ export class ObcWatch extends LitElement {
           svg`
             <circle cx="0" cy="0" r=${r} stroke="var(--instrument-frame-secondary-color)" stroke-width=${strokeWidth} fill="none" />
             <circle cx="0" cy="0" r=${r1} stroke="var(--instrument-frame-secondary-color)" stroke-width="1" fill="none" vector-effect="non-scaling-stroke" />
-            <circle cx="0" cy="0" r=${r2} stroke="var(--instrument-frame-secondary-color)" stroke-width="1" fill="var(--instrument-frame-primary-color)" vector-effect="non-scaling-stroke" />
+            <circle cx="0" cy="0" r=${r2} stroke="var(--instrument-frame-secondary-color)" stroke-width="1" fill=${this.innerRingFillColor} vector-effect="non-scaling-stroke" />
         `
         );
       }

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
@@ -232,12 +232,6 @@ export class ObcWatch extends LitElement {
   @property({type: Number}) clipTop: number = 0; // in percent of height
   @property({type: Number}) clipBottom: number = 0; // in percent of height
   @property({type: Number}) scaleWindIcon: number = 1;
-  @property({type: Boolean}) directionNotch: boolean = false;
-  @property({type: Number}) directionNotchAngle: number | undefined;
-  @property({type: Number}) directionNotchWidth: number = 28;
-  @property({type: Number}) directionNotchDepth: number = 16;
-  @property({type: String}) directionNotchColor: string =
-    'var(--instrument-frame-tertiary-color)';
   @property({type: Number}) rotation: number | undefined;
   @property({type: Boolean}) zoomToFitArc: boolean = false;
   @property({attribute: false}) arcFrame: ZoomToFitArcFrame | undefined;
@@ -411,16 +405,6 @@ export class ObcWatch extends LitElement {
             strokeColor: 'var(--instrument-frame-tertiary-color)',
             strokePosition: 'center',
             fillColor: 'none',
-            notch:
-              this.directionNotch && this.directionNotchAngle !== undefined
-                ? {
-                    angle: this.directionNotchAngle,
-                    width: this.directionNotchWidth,
-                    depth: this.directionNotchDepth,
-                    strokeColor: this.directionNotchColor,
-                    strokeWidth: 1,
-                  }
-                : undefined,
           })}
         `);
       } else {

--- a/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.stories.ts
@@ -100,5 +100,7 @@ export default meta;
 type Story = StoryObj<ObcWind>;
 
 export const Primary: Story = {
-  args: {},
+  args: {
+    currentWindFromDirection: 180,
+  },
 };

--- a/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
@@ -50,7 +50,7 @@ export class ObcWind extends LitElement {
     const minRadius = 50; // Optional: minimum bar length for visibility
     const notchWidth = 60;
     const notchDepth = 35;
-    const notchThickness = 6;
+    const notchThickness = 2.5;
     const notchOutlineThickness = notchThickness + 2;
     const center = {x: 0, y: 0};
 
@@ -112,7 +112,7 @@ export class ObcWind extends LitElement {
       <svg width="100%" height="100%" viewBox="-200 -200 400 400">
         <defs>
           <clipPath id=${this._notchClipId}>
-            <circle cx="0" cy="0" r=${maxRadius + 0.26} />
+            <circle cx="0" cy="0" r=${maxRadius + 0.56} />
           </clipPath>
         </defs>
         <mask id=${this._histMaskId}>
@@ -158,7 +158,7 @@ export class ObcWind extends LitElement {
           <path
             d=${notchPath}
             fill="none"
-            stroke="var(--instrument-frame-secondary-color)"
+            stroke="var(--instrument-frame-primary-color)"
             stroke-width=${notchThickness}
             vector-effect="non-scaling-stroke"
           />

--- a/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
@@ -14,6 +14,16 @@ export class ObcWind extends LitElement {
   private _histMaskId = `wind-hist-mask-${Math.random().toString(36).slice(2, 9)}`;
   private _notchClipId = `wind-notch-clip-${Math.random().toString(36).slice(2, 9)}`;
 
+  private static readonly HISTOGRAM_OUTER_RADIUS = 109;
+  private static readonly HISTOGRAM_MIN_RADIUS = 50;
+  private static readonly HISTOGRAM_BORDER_WIDTH = 1;
+  private static readonly NOTCH_WIDTH = 60;
+  private static readonly NOTCH_DEPTH = 35;
+  private static readonly NOTCH_THICKNESS = 7;
+  private static readonly NOTCH_OUTLINE_EXTRA = 2;
+  // Slight clip overscan keeps anti-aliased notch endpoints from being visibly cut.
+  private static readonly NOTCH_CLIP_OVERSCAN = 0.22;
+
   @property({type: Number}) currentWindFromDirection: number = 0;
   @property({type: Number}) currentWindSpeedBeaufort: number = 1;
   @property({type: Array, attribute: false})
@@ -46,14 +56,14 @@ export class ObcWind extends LitElement {
   }
 
   private renderWindHistogram() {
-    const maxRadius = 109; // Max bar length
-    const minRadius = 50; // Optional: minimum bar length for visibility
-    const notchWidth = 60;
-    const notchDepth = 35;
-    const notchThickness = 7;
-    const notchOutlineThickness = notchThickness + 2;
+    const maxRadius = ObcWind.HISTOGRAM_OUTER_RADIUS;
+    const minRadius = ObcWind.HISTOGRAM_MIN_RADIUS;
+    const notchWidth = ObcWind.NOTCH_WIDTH;
+    const notchDepth = ObcWind.NOTCH_DEPTH;
+    const notchThickness = ObcWind.NOTCH_THICKNESS;
+    const notchOutlineThickness = notchThickness + ObcWind.NOTCH_OUTLINE_EXTRA;
     const center = {x: 0, y: 0};
-    const borderWidth = 1;
+    const borderWidth = ObcWind.HISTOGRAM_BORDER_WIDTH;
 
     // Find the max occurrences for scaling
     const maxOccurrences = Math.max(
@@ -97,23 +107,24 @@ export class ObcWind extends LitElement {
       outerPathPoints += `L ${x2} ${y2} `;
     }
 
-    const notchAngle = ((this.currentWindFromDirection - 90) * Math.PI) / 180;
-    const notchTipRadius = maxRadius - notchDepth;
-    const baseX = center.x + maxRadius * Math.cos(notchAngle);
-    const baseY = center.y + maxRadius * Math.sin(notchAngle);
-    const leftX = baseX - (notchWidth / 2) * Math.sin(notchAngle);
-    const leftY = baseY + (notchWidth / 2) * Math.cos(notchAngle);
-    const rightX = baseX + (notchWidth / 2) * Math.sin(notchAngle);
-    const rightY = baseY - (notchWidth / 2) * Math.cos(notchAngle);
-    const tipX = center.x + notchTipRadius * Math.cos(notchAngle);
-    const tipY = center.y + notchTipRadius * Math.sin(notchAngle);
+    const notch = this.computeNotchGeometry({
+      directionDeg: this.currentWindFromDirection,
+      outerRadius: maxRadius,
+      width: notchWidth,
+      depth: notchDepth,
+    });
+    const {leftX, leftY, tipX, tipY, rightX, rightY} = notch;
     const notchPath = `M ${leftX} ${leftY} L ${tipX} ${tipY} L ${rightX} ${rightY}`;
 
     return html`
       <svg width="100%" height="100%" viewBox="-200 -200 400 400">
         <defs>
           <clipPath id=${this._notchClipId}>
-            <circle cx="0" cy="0" r=${maxRadius + 0.22} />
+            <circle
+              cx="0"
+              cy="0"
+              r=${maxRadius + ObcWind.NOTCH_CLIP_OVERSCAN}
+            />
           </clipPath>
         </defs>
         <mask id=${this._histMaskId}>
@@ -166,6 +177,30 @@ export class ObcWind extends LitElement {
         </g>
       </svg>
     `;
+  }
+
+  private computeNotchGeometry(options: {
+    directionDeg: number;
+    outerRadius: number;
+    width: number;
+    depth: number;
+  }) {
+    const {directionDeg, outerRadius, width, depth} = options;
+    const angle = ((directionDeg - 90) * Math.PI) / 180;
+    const tipRadius = outerRadius - depth;
+    const halfWidth = width / 2;
+
+    const baseX = outerRadius * Math.cos(angle);
+    const baseY = outerRadius * Math.sin(angle);
+
+    return {
+      leftX: baseX - halfWidth * Math.sin(angle),
+      leftY: baseY + halfWidth * Math.cos(angle),
+      rightX: baseX + halfWidth * Math.sin(angle),
+      rightY: baseY - halfWidth * Math.cos(angle),
+      tipX: tipRadius * Math.cos(angle),
+      tipY: tipRadius * Math.sin(angle),
+    };
   }
 
   static override styles = unsafeCSS(compentStyle);

--- a/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
@@ -11,6 +11,9 @@ export interface WindHistogramData {
 
 @customElement('obc-wind')
 export class ObcWind extends LitElement {
+  private _histMaskId = `wind-hist-mask-${Math.random().toString(36).slice(2, 9)}`;
+  private _notchClipId = `wind-notch-clip-${Math.random().toString(36).slice(2, 9)}`;
+
   @property({type: Number}) currentWindFromDirection: number = 0;
   @property({type: Number}) currentWindSpeedBeaufort: number = 1;
   @property({type: Array, attribute: false})
@@ -45,6 +48,10 @@ export class ObcWind extends LitElement {
   private renderWindHistogram() {
     const maxRadius = 109; // Max bar length
     const minRadius = 50; // Optional: minimum bar length for visibility
+    const notchWidth = 60;
+    const notchDepth = 35;
+    const notchThickness = 6;
+    const notchOutlineThickness = notchThickness + 2;
     const center = {x: 0, y: 0};
 
     // Find the max occurrences for scaling
@@ -89,9 +96,26 @@ export class ObcWind extends LitElement {
       outerPathPoints += `L ${x2} ${y2} `;
     }
 
+    const notchAngle = ((this.currentWindFromDirection - 90) * Math.PI) / 180;
+    const notchTipRadius = maxRadius - notchDepth;
+    const baseX = center.x + maxRadius * Math.cos(notchAngle);
+    const baseY = center.y + maxRadius * Math.sin(notchAngle);
+    const leftX = baseX - (notchWidth / 2) * Math.sin(notchAngle);
+    const leftY = baseY + (notchWidth / 2) * Math.cos(notchAngle);
+    const rightX = baseX + (notchWidth / 2) * Math.sin(notchAngle);
+    const rightY = baseY - (notchWidth / 2) * Math.cos(notchAngle);
+    const tipX = center.x + notchTipRadius * Math.cos(notchAngle);
+    const tipY = center.y + notchTipRadius * Math.sin(notchAngle);
+    const notchPath = `M ${leftX} ${leftY} L ${tipX} ${tipY} L ${rightX} ${rightY}`;
+
     return html`
       <svg width="100%" height="100%" viewBox="-200 -200 400 400">
-        <mask id="mask">
+        <defs>
+          <clipPath id=${this._notchClipId}>
+            <circle cx="0" cy="0" r=${maxRadius + 0.26} />
+          </clipPath>
+        </defs>
+        <mask id=${this._histMaskId}>
           <circle cx="0" cy="0" r="109" stroke-width="1" fill="white" />
           <path d="M 0 ${-maxRadius} ${outerPathPoints}Z" fill="black" />
           <circle
@@ -112,8 +136,33 @@ export class ObcWind extends LitElement {
           stroke="var(--instrument-regular-tertiary-color)"
           stroke-width="1"
           fill="var(--instrument-regular-tertiary-color)"
-          mask="url(#mask)"
+          mask="url(#${this._histMaskId})"
         />
+        <circle
+          cx="0"
+          cy="0"
+          r="109"
+          vector-effect="non-scaling-stroke"
+          stroke="var(--instrument-regular-tertiary-color)"
+          stroke-width="1"
+          fill="none"
+        />
+        <g clip-path="url(#${this._notchClipId})">
+          <path
+            d=${notchPath}
+            fill="none"
+            stroke="var(--instrument-regular-tertiary-color)"
+            stroke-width=${notchOutlineThickness}
+            vector-effect="non-scaling-stroke"
+          />
+          <path
+            d=${notchPath}
+            fill="none"
+            stroke="var(--instrument-frame-secondary-color)"
+            stroke-width=${notchThickness}
+            vector-effect="non-scaling-stroke"
+          />
+        </g>
       </svg>
     `;
   }

--- a/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
@@ -35,6 +35,7 @@ export class ObcWind extends LitElement {
       <div class="wrapper">
         <obc-watch
           .watchCircleType=${WatchCircleType.double}
+          innerRingFillColor="var(--instrument-frame-primary-color)"
           .windFromDirectionDeg=${this.currentWindFromDirection}
           .wind=${this.currentWindSpeedBeaufort}
           .windSymbolRadius=${118 / 0.8}

--- a/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/wind/wind.ts
@@ -50,9 +50,10 @@ export class ObcWind extends LitElement {
     const minRadius = 50; // Optional: minimum bar length for visibility
     const notchWidth = 60;
     const notchDepth = 35;
-    const notchThickness = 2.5;
+    const notchThickness = 7;
     const notchOutlineThickness = notchThickness + 2;
     const center = {x: 0, y: 0};
+    const borderWidth = 1;
 
     // Find the max occurrences for scaling
     const maxOccurrences = Math.max(
@@ -112,39 +113,39 @@ export class ObcWind extends LitElement {
       <svg width="100%" height="100%" viewBox="-200 -200 400 400">
         <defs>
           <clipPath id=${this._notchClipId}>
-            <circle cx="0" cy="0" r=${maxRadius + 0.56} />
+            <circle cx="0" cy="0" r=${maxRadius + 0.22} />
           </clipPath>
         </defs>
         <mask id=${this._histMaskId}>
-          <circle cx="0" cy="0" r="109" stroke-width="1" fill="white" />
+          <circle cx="0" cy="0" r=${maxRadius} stroke-width="1" fill="white" />
           <path d="M 0 ${-maxRadius} ${outerPathPoints}Z" fill="black" />
           <circle
             cx="0"
             cy="0"
-            r="109"
+            r=${maxRadius}
             vector-effect="non-scaling-stroke"
             stroke="white"
-            stroke-width="1"
+            stroke-width="0"
             fill="transparent"
           />
         </mask>
         <circle
           cx="0"
           cy="0"
-          r="109"
+          r=${maxRadius}
           vector-effect="non-scaling-stroke"
           stroke="var(--instrument-regular-tertiary-color)"
-          stroke-width="1"
+          stroke-width="0"
           fill="var(--instrument-regular-tertiary-color)"
           mask="url(#${this._histMaskId})"
         />
         <circle
           cx="0"
           cy="0"
-          r="109"
+          r=${maxRadius}
           vector-effect="non-scaling-stroke"
           stroke="var(--instrument-regular-tertiary-color)"
-          stroke-width="1"
+          stroke-width=${borderWidth}
           fill="none"
         />
         <g clip-path="url(#${this._notchClipId})">

--- a/packages/openbridge-webcomponents/src/svghelpers/circle.ts
+++ b/packages/openbridge-webcomponents/src/svghelpers/circle.ts
@@ -1,5 +1,20 @@
 import {svg} from 'lit';
 
+interface CircleNotch {
+  /** Angle in watch coordinates where 0 is 12 o'clock and values increase clockwise. */
+  angle: number;
+  /** Visual width of the notch at the ring edge. */
+  width: number;
+  /** How far the notch points inward from the ring edge. */
+  depth: number;
+  /** Optional fill color for the notch body. Defaults to none. */
+  fillColor?: string;
+  /** Optional stroke color for the notch outline. */
+  strokeColor?: string;
+  /** Optional stroke width for the notch outline. */
+  strokeWidth?: number;
+}
+
 export function circle(
   id: string,
   data: {
@@ -8,13 +23,30 @@ export function circle(
     strokeColor: string;
     strokePosition: 'inside' | 'outside' | 'center';
     fillColor: string;
+    notch?: CircleNotch;
   }
 ) {
+  const notch = data.notch
+    ? svg`<g transform="rotate(${data.notch.angle})">
+        <path
+          d="M ${-data.notch.width / 2} ${-data.radius} L 0 ${-(data.radius - data.notch.depth)} L ${data.notch.width / 2} ${-data.radius}"
+          fill=${data.notch.fillColor ?? 'none'}
+          stroke=${data.notch.strokeColor ?? 'currentColor'}
+          stroke-width=${data.notch.strokeWidth ?? 1}
+          vector-effect="non-scaling-stroke"
+          paint-order="stroke fill"
+        />
+      </g>`
+    : null;
+
   if (data.strokePosition === 'center') {
-    return svg`<circle id=${id} cx="0" cy="0" 
+    return svg`<g>
+      <circle id=${id} cx="0" cy="0" 
       r=${data.radius} vector-effect="non-scaling-stroke" 
       stroke=${data.strokeColor}  stroke-width=${data.strokeWidth} 
-      fill=${data.fillColor}>`;
+      fill=${data.fillColor}></circle>
+      ${notch}
+    </g>`;
   } else if (data.strokePosition === 'inside') {
     return svg`
 		<defs>
@@ -32,15 +64,19 @@ export function circle(
       }  stroke-width=${data.strokeWidth * 2} fill=${
         data.fillColor
       } clip-path="url(#clip${id})"/>
+			${notch}
 		</g>
   `;
   } else {
     return svg`
-		<circle id=${id} cx="0" cy="0" r=${
-      data.radius
-    } vector-effect="non-scaling-stroke" stroke=${
-      data.strokeColor
-    } stroke-width=${data.strokeWidth * 2} fill=${data.fillColor}/>
+		<g>
+			<circle id=${id} cx="0" cy="0" r=${
+        data.radius
+      } vector-effect="non-scaling-stroke" stroke=${
+        data.strokeColor
+      } stroke-width=${data.strokeWidth * 2} fill=${data.fillColor}/>
+			${notch}
+		</g>
 		  `;
   }
 }

--- a/packages/openbridge-webcomponents/src/svghelpers/circle.ts
+++ b/packages/openbridge-webcomponents/src/svghelpers/circle.ts
@@ -1,6 +1,6 @@
 import {svg} from 'lit';
 
-interface CircleNotch {
+export interface CircleNotch {
   angle: number;
   width: number;
   depth: number;

--- a/packages/openbridge-webcomponents/src/svghelpers/circle.ts
+++ b/packages/openbridge-webcomponents/src/svghelpers/circle.ts
@@ -1,17 +1,11 @@
 import {svg} from 'lit';
 
 interface CircleNotch {
-  /** Angle in watch coordinates where 0 is 12 o'clock and values increase clockwise. */
   angle: number;
-  /** Visual width of the notch at the ring edge. */
   width: number;
-  /** How far the notch points inward from the ring edge. */
   depth: number;
-  /** Optional fill color for the notch body. Defaults to none. */
   fillColor?: string;
-  /** Optional stroke color for the notch outline. */
   strokeColor?: string;
-  /** Optional stroke width for the notch outline. */
   strokeWidth?: number;
 }
 

--- a/packages/openbridge-webcomponents/src/svghelpers/circle.ts
+++ b/packages/openbridge-webcomponents/src/svghelpers/circle.ts
@@ -1,14 +1,5 @@
 import {svg} from 'lit';
 
-export interface CircleNotch {
-  angle: number;
-  width: number;
-  depth: number;
-  fillColor?: string;
-  strokeColor?: string;
-  strokeWidth?: number;
-}
-
 export function circle(
   id: string,
   data: {
@@ -17,29 +8,14 @@ export function circle(
     strokeColor: string;
     strokePosition: 'inside' | 'outside' | 'center';
     fillColor: string;
-    notch?: CircleNotch;
   }
 ) {
-  const notch = data.notch
-    ? svg`<g transform="rotate(${data.notch.angle})">
-        <path
-          d="M ${-data.notch.width / 2} ${-data.radius} L 0 ${-(data.radius - data.notch.depth)} L ${data.notch.width / 2} ${-data.radius}"
-          fill=${data.notch.fillColor ?? 'none'}
-          stroke=${data.notch.strokeColor ?? 'currentColor'}
-          stroke-width=${data.notch.strokeWidth ?? 1}
-          vector-effect="non-scaling-stroke"
-          paint-order="stroke fill"
-        />
-      </g>`
-    : null;
-
   if (data.strokePosition === 'center') {
     return svg`<g>
       <circle id=${id} cx="0" cy="0" 
       r=${data.radius} vector-effect="non-scaling-stroke" 
       stroke=${data.strokeColor}  stroke-width=${data.strokeWidth} 
       fill=${data.fillColor}></circle>
-      ${notch}
     </g>`;
   } else if (data.strokePosition === 'inside') {
     return svg`
@@ -58,7 +34,6 @@ export function circle(
       }  stroke-width=${data.strokeWidth * 2} fill=${
         data.fillColor
       } clip-path="url(#clip${id})"/>
-			${notch}
 		</g>
   `;
   } else {
@@ -69,7 +44,6 @@ export function circle(
       } vector-effect="non-scaling-stroke" stroke=${
         data.strokeColor
       } stroke-width=${data.strokeWidth * 2} fill=${data.fillColor}/>
-			${notch}
 		</g>
 		  `;
   }


### PR DESCRIPTION
> [!WARNING]
> A better approach is in the works now. I will close this PR when that new PR is ready. 
> [slack discussion](https://openbridgegroup.slack.com/archives/C06LXTCR269/p1777540594904169?thread_ts=1777538316.743459&cid=C06LXTCR269)

## Context

I'm a consultant at [ECC](https://www.ecc.no/) and a senior frontend engineer from [Olavstoppen](https://www.olavstoppen.no/). We use the open bridge library for one of our apps and I am putting this PR up for suggestion in response to user feedback on our end and to contribute back to the library. 

## Problem

<img width="996" height="604" alt="Screenshot 2026-04-30 at 09 02 53" src="https://github.com/user-attachments/assets/bd836320-2a42-47f3-bc4c-54f3778a50bf" />

One of our users mentioned that the wind arrow in the wind instrument feels a bit small. We display the wind instrument at medium to small sizes sometimes so improving the legibility of the wind direction at smaller sizes would help us. It would also generally help make the instrument more scalable. 

## Solution

I had this idea that this could be improved with a larger "notch" inside the watch face. That way, even if you cant see the smaller wind direction symbol at least the wind direction itself is always obvious even at small sizes. 

This idea was originally suggested in slack for initial feedback and I am now suggesting this PR to help contribute back up into Open Bridge. 

[slack conversation](https://openbridgegroup.slack.com/archives/C06LXTCR269/p1776159745046019)

<img width="1213" height="914" alt="Screenshot 2026-04-30 at 09 12 42" src="https://github.com/user-attachments/assets/aa6f1520-9512-48d6-9225-d73d7af05fd2" />
<img width="1222" height="914" alt="Screenshot 2026-04-30 at 09 13 02" src="https://github.com/user-attachments/assets/07bba2ef-6887-4ecf-9000-3716e1eae361" />
<img width="1221" height="914" alt="Screenshot 2026-04-30 at 09 13 19" src="https://github.com/user-attachments/assets/e9a0fa04-38fe-4a3e-a93a-315c61781efb" />

## Approach

The notch is rendered directly inside the wind histogram SVG overlay (on top
of the histogram fill, correctly z-ordered). It is drawn as an open V-shape
using a dual-stroke technique — a wider outer stroke in
`--instrument-regular-tertiary-color` and a narrower inner stroke in
`--instrument-frame-primary-color` — giving it contrast on any theme surface.
A `<clipPath>` constrains the notch to the histogram ring boundary.

All geometry is computed by a private `computeNotchGeometry()` helper and
driven by named `private static readonly` constants, avoiding magic numbers
throughout.

## Testing

- Verified visually in Storybook across `day`, `dusk`, `night`, and `bright`
  themes at multiple instrument sizes.
- No TypeScript or lint errors (`npm run lint && npm run typecheck`).