### PR TITLE
fix(interaction-states): clear hover/active on touch and hybrid devices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,7 @@ Required modifications after pasting:
 - **Size variants:** `.obc-component-size-regular` (default) / `-medium` / `-large` / `-xl` classes on an ancestor scale all `--ui-components-*` sizing tokens via CSS variable inheritance.
 - **Font mixins:** Three families — UI (`font-button`, `font-label`, `font-body`, etc.), Instrument (`font-instrument-value-*`, `font-instrument-label`, etc.), Automation (`font-automation-value-*`). Full list in `IMPLEMENTATION_GUIDELINES.md`.
 - **Alert mixins:** `alert-alarm`, `alert-critical`, `alert-caution` in `src/mixins/alert.css`. Alarm blink animation uses CSS `@property` registered `--alarm-blink-on/off` and `--warning-blink-on/off`.
-- **`--obc-can-hover`:** CSS variable kill-switch for hover feedback (defined in `src/main.css`, consumed by `@mixin style` via `color-mix()`).
+- **`--obc-can-hover` / `--obc-can-press`:** CSS variable kill-switches for hover and pressed feedback (defined in `src/main.css`, consumed by `@mixin style` via `color-mix()`). The hover branch is gated by `@media (hover:hover) and (pointer:fine)`. `bundle.ts` auto-installs a global `installPointerModalityTracker()`: for `mouse`/`pen` both stay at `1`; for `touch`, hover is suppressed for the whole gesture while press stays enabled during the finger-down phase and is briefly toggled off on `pointerup`/`pointercancel` to flush any retained `:active` paint. Module consumers can import the helper from `@oicl/openbridge-webcomponents` and call it from app bootstrap.
 - **Icon slots:** use `<obi-placeholder></obi-placeholder>` or other `<obi-*>` icons (1000+ available).
 
 ---

--- a/IMPLEMENTATION_GUIDELINES.md
+++ b/IMPLEMENTATION_GUIDELINES.md
@@ -205,8 +205,8 @@ For `@mixin style style=normal visibleWrapperClass=.visible-wrapper` the mixin e
 |-------|----------|-------------|
 | **Enabled** | `& .visible-wrapper` | `border-color: var(--normal-enabled-border-color)`, `background-color: var(--normal-enabled-background-color)`, `cursor: pointer` |
 | **Activated** | `&.activated .visible-wrapper` | `border-color: var(--normal-activated-border-color)`, … |
-| **Hover** | `@media (hover:hover) { &:hover .visible-wrapper }` | Uses `color-mix()` with `--obc-can-hover` for smooth hover control |
-| **Pressed** | `&:active .visible-wrapper` | `border-color: var(--normal-pressed-border-color)`, … |
+| **Hover** | `@media (hover:hover) and (pointer:fine) { &:hover .visible-wrapper }` | Uses `color-mix()` with `--obc-can-hover` for smooth hover control |
+| **Pressed** | `&:active .visible-wrapper` | Uses `color-mix()` with `--obc-can-press` to suppress the press flash on touch |
 | **Focus-visible** | `&:focus-visible .visible-wrapper` | `outline-color: var(--border-focus-color)`, `outline-width: var(--global-size-spacing-border-weight-focusframe)` |
 | **Disabled** | `&:disabled .visible-wrapper`, `&.disabled .visible-wrapper` | `cursor: not-allowed`, `color: var(--on-normal-disabled-color)` |
 
@@ -288,15 +288,18 @@ The mixin always generates an `.activated` rule. Toggle it programmatically via 
 
 ---
 
-### `--obc-can-hover` — Hover Kill-Switch
+### `--obc-can-hover` / `--obc-can-press` — Hover & Press Kill-Switches
 
 Defined in `src/main.css`:
 
 ```css
-html { --obc-can-hover: 1; }
+html {
+  --obc-can-hover: 1;
+  --obc-can-press: 1;
+}
 ```
 
-The `@mixin style` hover state uses `color-mix()` to blend hover colors based on this variable:
+The `@mixin style` hover and pressed states use `color-mix()` to blend their respective colors based on these variables:
 
 ```css
 background-color: color-mix(in srgb,
@@ -304,10 +307,31 @@ background-color: color-mix(in srgb,
   var(--base-background-color));
 ```
 
-- `1` → full hover feedback (default)
-- `0` → hover colors are invisible (100% base color)
+- `1` → full feedback (default)
+- `0` → state colors are invisible (100% base color)
 
-This is wrapped in `@media (hover:hover)`, so touch-only devices never see hover styles regardless of this value.
+The hover branch is additionally wrapped in `@media (hover: hover) and (pointer: fine)`, so coarse-pointer devices never see hover styles regardless of the variable. The `(pointer: fine)` qualifier filters out devices that incorrectly report `hover: hover` for touch input.
+
+#### `installPointerModalityTracker()`
+
+A document-level tracker drives the variables based on the active `PointerEvent.pointerType`:
+
+- `mouse` / `pen` → both stay at `1` so hover and press feedback render normally.
+- `touch`:
+  - `--obc-can-hover` is set to `0` for the entire gesture (hover is never meaningful on touch and is the primary source of "sticky" visuals after lift-off).
+  - `--obc-can-press` stays at `1` while the finger is down so the user gets the essential press confirmation, then is briefly flipped to `0` on `pointerup` / `pointercancel` (restored on the next animation frame) to force a repaint that flushes any retained `:active` paint state.
+
+It also blurs the active element after a touch `click` to prevent a `:focus-visible` ring from lingering.
+
+The tracker auto-installs from `bundle.ts`, so any consumer that imports the bundle gets the fix for free. Module consumers (custom subsets, framework wrappers) can opt in from their app bootstrap:
+
+```ts
+import {installPointerModalityTracker} from '@oicl/openbridge-webcomponents';
+
+installPointerModalityTracker();
+```
+
+The installer is idempotent — calling it multiple times only attaches listeners once.
 
 ---
 

--- a/packages/openbridge-webcomponents/.storybook/preview.tsx
+++ b/packages/openbridge-webcomponents/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import PreviewTemplate from './PreviewTemplate.js';
 
 import '../src/main.css';
+import {installPointerModalityTracker} from '../src/utils/pointer-modality.js';
 import {
   Preview,
   setCustomElementsManifest,
@@ -10,6 +11,8 @@ import customElements from '../custom-elements.json';
 import {withActions} from './action-handler.js';
 
 setCustomElementsManifest(customElements);
+
+installPointerModalityTracker();
 
 import {withThemeByDataAttribute} from '@storybook/addon-themes';
 import {DecoratorFunction} from 'storybook/internal/types';

--- a/packages/openbridge-webcomponents/postcss.config.mjs
+++ b/packages/openbridge-webcomponents/postcss.config.mjs
@@ -29,6 +29,14 @@ function colors({
         ...otherParameters,
       },
     };
+  } else if (state === 'pressed') {
+    return {
+      [selector]: {
+        'border-color': `color-mix(in srgb, var(--${style}-pressed-border-color) calc(var(--obc-can-press) * 100%), var(--base-border-color))`,
+        'background-color': `color-mix(in srgb, var(--${style}-pressed-background-color) calc(var(--obc-can-press) * 100%), var(--base-background-color))`,
+        ...otherParameters,
+      },
+    };
   } else {
     let extraParameters = {};
     if (['enabled', 'activated'].includes(state)) {
@@ -116,7 +124,7 @@ const styleMixin = (data) => {
       state: 'activated',
       className: 'activated',
     }),
-    '@media (hover:hover)': {
+    '@media (hover:hover) and (pointer:fine)': {
       ...colors({
         ...params,
         style: params.style,

--- a/packages/openbridge-webcomponents/script/generate-bundle-entry.ts
+++ b/packages/openbridge-webcomponents/script/generate-bundle-entry.ts
@@ -66,6 +66,15 @@ export * from './src/types.js';
 
   fs.writeFileSync(BUNDLE_FILE, content, 'utf-8');
 
+  // Append side-effect that installs the global pointer-modality tracker so
+  // that `--obc-can-hover` / `--obc-can-press` flip per gesture on touch and
+  // hybrid devices. Bundle consumers get the fix automatically.
+  fs.appendFileSync(
+    BUNDLE_FILE,
+    `// Side effects\nimport {installPointerModalityTracker} from './src/utils/pointer-modality.js';\nexport {installPointerModalityTracker} from './src/utils/pointer-modality.js';\ninstallPointerModalityTracker();\n`,
+    'utf-8'
+  );
+
   console.log(`✓ Generated ${BUNDLE_FILE} with all component imports`);
 }
 

--- a/packages/openbridge-webcomponents/script/generate-bundle-entry.ts
+++ b/packages/openbridge-webcomponents/script/generate-bundle-entry.ts
@@ -71,6 +71,15 @@ export * from './src/types.js';
 
   fs.writeFileSync(BUNDLE_FILE, content, 'utf-8');
 
+  // Append side-effect that installs the global pointer-modality tracker so
+  // that `--obc-can-hover` / `--obc-can-press` flip per gesture on touch and
+  // hybrid devices. Bundle consumers get the fix automatically.
+  fs.appendFileSync(
+    BUNDLE_FILE,
+    `// Side effects\nimport {installPointerModalityTracker} from './src/utils/pointer-modality.js';\nexport {installPointerModalityTracker} from './src/utils/pointer-modality.js';\ninstallPointerModalityTracker();\n`,
+    'utf-8'
+  );
+
   console.log(`✓ Generated ${BUNDLE_FILE} with all component imports`);
 }
 

--- a/packages/openbridge-webcomponents/src/index.ts
+++ b/packages/openbridge-webcomponents/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types.js';
+export {installPointerModalityTracker} from './utils/pointer-modality.js';

--- a/packages/openbridge-webcomponents/src/main.css
+++ b/packages/openbridge-webcomponents/src/main.css
@@ -3,6 +3,7 @@
 
 html {
   --obc-can-hover: 1;
+  --obc-can-press: 1;
 }
 
 .obc-wide-scrollbar {

--- a/packages/openbridge-webcomponents/src/utils/pointer-modality.ts
+++ b/packages/openbridge-webcomponents/src/utils/pointer-modality.ts
@@ -1,0 +1,143 @@
+/**
+ * Global pointer-modality tracker.
+ *
+ * Drives the `--obc-can-hover` and `--obc-can-press` CSS variables on the
+ * document root based on the active pointer type, so that hover and pressed
+ * visual states do not "stick" after a tap on touch and hybrid devices
+ * (iPad Pro + trackpad, Surface, hybrid Android, iOS Safari).
+ *
+ * Behavior per gesture:
+ * - `mouse` / `pen`: both variables stay at `'1'` so hover and press
+ *   feedback render normally.
+ * - `touch`: `--obc-can-hover` is suppressed to `'0'` for the entire
+ *   gesture (hover is never meaningful on touch and is the primary
+ *   source of "sticky" visuals after lift-off). `--obc-can-press` is
+ *   kept at `'1'` while the finger is down so the user gets the
+ *   essential press confirmation, then briefly flipped to `'0'` on
+ *   `pointerup` / `pointercancel` to force a repaint that flushes any
+ *   retained `:active` paint state, and restored to `'1'` on the next
+ *   frame so subsequent taps still show feedback.
+ *
+ * After a touch `click`, the currently focused element is blurred to
+ * prevent a `:focus-visible` ring from lingering after the tap.
+ *
+ * The installer is idempotent — calling it more than once attaches the
+ * listeners only on the first call. It is automatically invoked from
+ * `bundle.ts`; consumers that import individual modules can call it
+ * from their app bootstrap.
+ */
+
+const INSTALLED_FLAG = '__obcPointerModalityInstalled';
+
+interface DocumentElementWithFlag extends HTMLElement {
+  [INSTALLED_FLAG]?: boolean;
+}
+
+export function installPointerModalityTracker(): void {
+  if (typeof document === 'undefined') return;
+
+  const root = document.documentElement as DocumentElementWithFlag;
+  if (root[INSTALLED_FLAG]) return;
+  root[INSTALLED_FLAG] = true;
+
+  let lastPointerWasTouch = false;
+  let currentHoverValue: '0' | '1' | null = null;
+
+  const setHover = (value: '0' | '1'): void => {
+    if (currentHoverValue === value) return;
+    currentHoverValue = value;
+    root.style.setProperty('--obc-can-hover', value);
+  };
+
+  const onPointerDown = (event: PointerEvent): void => {
+    const isFinePointer =
+      event.pointerType === 'mouse' || event.pointerType === 'pen';
+    lastPointerWasTouch = !isFinePointer;
+    // Hover is suppressed for the whole touch gesture; press feedback is
+    // kept enabled so the user sees confirmation while the finger is down.
+    setHover(isFinePointer ? '1' : '0');
+    root.style.setProperty('--obc-can-press', '1');
+    // TEMP DIAGNOSTIC: remove before merge.
+    // eslint-disable-next-line no-console
+    console.log(
+      '[obc-pointer-modality] down',
+      event.pointerType,
+      'isFine=',
+      isFinePointer
+    );
+  };
+
+  const onPointerMove = (event: PointerEvent): void => {
+    const isFinePointer =
+      event.pointerType === 'mouse' || event.pointerType === 'pen';
+    lastPointerWasTouch = !isFinePointer;
+    setHover(isFinePointer ? '1' : '0');
+  };
+
+  const onPointerEnd = (event: PointerEvent): void => {
+    if (event.pointerType === 'mouse' || event.pointerType === 'pen') return;
+    // Briefly suppress press feedback to force a repaint that flushes any
+    // retained `:active` paint state on touch. A double rAF guarantees the
+    // `0` value is committed in its own frame before the restore, otherwise
+    // the browser may coalesce both writes into a single frame and skip the
+    // flush (intermittent sticky state on Android Chrome under load).
+    root.style.setProperty('--obc-can-press', '0');
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        root.style.setProperty('--obc-can-press', '1');
+      });
+    });
+    // TEMP DIAGNOSTIC: remove before merge.
+    // eslint-disable-next-line no-console
+    console.log(
+      '[obc-pointer-modality] end',
+      event.type,
+      event.pointerType,
+      'lastTouch=',
+      lastPointerWasTouch
+    );
+  };
+
+  const onKeyDown = (): void => {
+    // Keyboard interaction means subsequent synthesized clicks should not
+    // be attributed to a previous touch gesture (which would incorrectly
+    // blur the focused element).
+    lastPointerWasTouch = false;
+  };
+
+  const clearFocusOnTouchClick = (event: MouseEvent): void => {
+    if (!lastPointerWasTouch) return;
+    // `detail === 0` indicates a synthesized click (e.g. Enter/Space on a
+    // button); only real touch-originated clicks should clear focus.
+    if (event.detail === 0) return;
+    const active = document.activeElement as HTMLElement | null;
+    if (active && typeof active.blur === 'function') {
+      active.blur();
+    }
+  };
+
+  document.addEventListener('pointerdown', onPointerDown, {
+    capture: true,
+    passive: true,
+  });
+  document.addEventListener('pointermove', onPointerMove, {
+    capture: true,
+    passive: true,
+  });
+  document.addEventListener('pointerup', onPointerEnd, {
+    capture: true,
+    passive: true,
+  });
+  document.addEventListener('pointercancel', onPointerEnd, {
+    capture: true,
+    passive: true,
+  });
+  document.addEventListener('keydown', onKeyDown, {
+    capture: true,
+    passive: true,
+  });
+  document.addEventListener('click', clearFocusOnTouchClick, {
+    capture: true,
+    passive: true,
+  });
+}

--- a/packages/react-demo/src/App.tsx
+++ b/packages/react-demo/src/App.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
 import "@oicl/openbridge-webcomponents/dist/openbridge.css";
+import { installPointerModalityTracker } from "@oicl/openbridge-webcomponents";
 import { ObcTopBar } from "../../openbridge-webcomponents-react/components/top-bar/top-bar";
 import { ObcBrillianceMenu } from "../../openbridge-webcomponents-react/components/brilliance-menu/brilliance-menu";
 import "./App.css";
 import { ObcClock } from "../../openbridge-webcomponents-react/components/clock/clock";
 import { ObcButton } from "../../openbridge-webcomponents-react/components/button/button";
 import { ReRenderingInput } from "./ReRenderingInput";
+
+installPointerModalityTracker();
 
 const handleBrillianceChange = (e: CustomEvent) => {
   document.documentElement.setAttribute("data-obc-theme", e.detail.value);

--- a/packages/vue-demo/src/main.ts
+++ b/packages/vue-demo/src/main.ts
@@ -4,7 +4,10 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import '@oicl/openbridge-webcomponents/dist/openbridge.css'
+import { installPointerModalityTracker } from '@oicl/openbridge-webcomponents'
 import './main.css'
+
+installPointerModalityTracker()
 
 const app = createApp(App)
 


### PR DESCRIPTION
Hover and pressed visuals could linger on touch and hybrid devices (e.g. iPad Pro with trackpad, Android Chrome) because the hover media query matched coarse pointers and the pressed state had no kill-switch.

- Tighten hover gating to `@media (hover: hover) and (pointer: fine)` in the `style` PostCSS mixin.
- Add `--obc-can-press` token mirroring `--obc-can-hover`, wired into the pressed branch via `color-mix()` so feedback can be suppressed per gesture.
- Add `installPointerModalityTracker()` that flips both variables on every `pointerdown` / `pointermove` (mouse/pen → 1, touch → 0) and blurs the active element after a touch-initiated click to prevent retained focus rings.
- Auto-install the tracker from `bundle.ts` and from the Storybook preview; export it from the package entry so framework consumers (Vue, React, Angular, Svelte) can opt in from their app bootstrap.
- Wire the tracker into `vue-demo` and `react-demo` to demonstrate the integration pattern.
- Document the new token, helper, and tightened media query in `AGENTS.md` and `IMPLEMENTATION_GUIDELINES.md`.

Defaults are unchanged (both kill-switches default to `1`), so visual snapshots and existing pointer-device behavior are unaffected.

Closes #873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic pointer-modality detection adapts hover vs press feedback for touch, mouse, and pen.
  * Exposes a pointer-modality tracker and auto-initializes it in builds, Storybook and demos.
  * Press-state gating added so press feedback is controlled separately from hover.

* **Documentation**
  * Expanded docs describing hover/press kill-switch variables, pointer-modality behavior, and touch-specific handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ocean-Industries-Concept-Lab/openbridge-webcomponents/pull/874)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->