### PR TITLE
fix(indicators): use enums in type definitions

### DIFF
--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-indicator/compass-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-indicator/compass-indicator.ts
@@ -56,10 +56,10 @@ export class ObcCompassIndicator extends LitElement {
   angle = 0;
 
   @property({type: String})
-  type: string = CompassIndicatorType.Regular;
+  type: CompassIndicatorType = CompassIndicatorType.Regular;
 
   @property({type: String})
-  direction: string = CompassIndicatorDirection.Heading;
+  direction: CompassIndicatorDirection = CompassIndicatorDirection.Heading;
 
   private get normalizedAngle(): number {
     return normalizeAngle(this.angle);

--- a/packages/openbridge-webcomponents/src/navigation-instruments/depth-indicator/depth-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/depth-indicator/depth-indicator.ts
@@ -23,7 +23,7 @@ const DOT_R = 3;
 @customElement('obc-depth-indicator')
 export class ObcDepthIndicator extends LitElement {
   @property({type: String})
-  variant: string = ObcDepthIndicatorVariant.outline;
+  variant: ObcDepthIndicatorVariant = ObcDepthIndicatorVariant.outline;
 
   @property({type: Array})
   values: number[] = [];

--- a/packages/openbridge-webcomponents/src/navigation-instruments/gauge-trend-indicator/gauge-trend-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/gauge-trend-indicator/gauge-trend-indicator.ts
@@ -82,7 +82,7 @@ function createFramePath() {
 @customElement('obc-gauge-trend-indicator')
 export class ObcGaugeTrendIndicator extends LitElement {
   @property({type: String})
-  type: string = ObcGaugeTrendIndicatorType.Fill;
+  type: ObcGaugeTrendIndicatorType = ObcGaugeTrendIndicatorType.Fill;
 
   @property({type: Array})
   data: number[] = [];

--- a/packages/openbridge-webcomponents/src/navigation-instruments/heading-indicator/heading-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/heading-indicator/heading-indicator.ts
@@ -48,7 +48,7 @@ export class ObcHeadingIndicator extends LitElement {
   private idBase = `heading-indicator-${Math.random().toString(36).slice(2, 9)}`;
 
   @property({type: String})
-  type: string = HeadingIndicatorType.HDG;
+  type: HeadingIndicatorType = HeadingIndicatorType.HDG;
 
   @property({type: Number})
   angle = 0;

--- a/packages/openbridge-webcomponents/src/navigation-instruments/heave-indicator/heave-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/heave-indicator/heave-indicator.ts
@@ -75,7 +75,7 @@ const TRAVEL_HALF_PX = Math.min(
  */
 @customElement('obc-heave-indicator')
 export class ObcHeaveIndicator extends LitElement {
-  @property({type: String}) type: string = HeaveIndicatorType.enhanced;
+  @property({type: String}) type: HeaveIndicatorType = HeaveIndicatorType.enhanced;
 
   @property({type: Number}) value = 0;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/heave-indicator/heave-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/heave-indicator/heave-indicator.ts
@@ -75,7 +75,8 @@ const TRAVEL_HALF_PX = Math.min(
  */
 @customElement('obc-heave-indicator')
 export class ObcHeaveIndicator extends LitElement {
-  @property({type: String}) type: HeaveIndicatorType = HeaveIndicatorType.enhanced;
+  @property({type: String}) type: HeaveIndicatorType =
+    HeaveIndicatorType.enhanced;
 
   @property({type: Number}) value = 0;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/main-engine-indicator/propulsion-main-engine-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/main-engine-indicator/propulsion-main-engine-indicator.ts
@@ -134,9 +134,9 @@ export class ObcMainEngineIndicator extends LitElement {
     this.requestUpdate('speed', old);
   }
 
-  @property({type: String}) state: string = InstrumentState.active;
+  @property({type: String}) state: InstrumentState = InstrumentState.active;
 
-  @property({type: String}) priority: string = Priority.regular;
+  @property({type: String}) priority: Priority = Priority.regular;
 
   @property({type: Boolean}) hasSilhouette = false;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/pitch-indicator/pitch-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/pitch-indicator/pitch-indicator.ts
@@ -68,7 +68,8 @@ const TRACK_D =
  */
 @customElement('obc-pitch-indicator')
 export class ObcPitchIndicator extends LitElement {
-  @property({type: String}) type: PitchIndicatorType = PitchIndicatorType.enhanced;
+  @property({type: String}) type: PitchIndicatorType =
+    PitchIndicatorType.enhanced;
 
   @property({type: Number}) value = 0;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/pitch-indicator/pitch-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/pitch-indicator/pitch-indicator.ts
@@ -68,7 +68,7 @@ const TRACK_D =
  */
 @customElement('obc-pitch-indicator')
 export class ObcPitchIndicator extends LitElement {
-  @property({type: String}) type: string = PitchIndicatorType.enhanced;
+  @property({type: String}) type: PitchIndicatorType = PitchIndicatorType.enhanced;
 
   @property({type: Number}) value = 0;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/propulsion-azimuth-indicator/propulsion-azimuth-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/propulsion-azimuth-indicator/propulsion-azimuth-indicator.ts
@@ -103,7 +103,7 @@ function topCircleSideIntersection(
  */
 @customElement('obc-propulsion-azimuth-indicator')
 export class ObcPropulsionAzimuthIndicator extends LitElement {
-  @property({type: String}) type: string =
+  @property({type: String}) type: PropulsionAzimuthIndicatorType =
     PropulsionAzimuthIndicatorType.enhanced;
 
   @property({type: Boolean, attribute: 'has-silhouette'}) hasSilhouette = false;
@@ -112,7 +112,7 @@ export class ObcPropulsionAzimuthIndicator extends LitElement {
 
   @property({type: Number}) value = 0;
 
-  @property({type: String}) state: string = InstrumentState.active;
+  @property({type: String}) state: InstrumentState = InstrumentState.active;
 
   static override styles = css`
     :host {

--- a/packages/openbridge-webcomponents/src/navigation-instruments/roll-indicator/roll-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/roll-indicator/roll-indicator.ts
@@ -64,7 +64,8 @@ let nextTrackClipId = 0;
  */
 @customElement('obc-roll-indicator')
 export class ObcRollIndicator extends LitElement {
-  @property({type: String}) type: RollIndicatorType = RollIndicatorType.enhanced;
+  @property({type: String}) type: RollIndicatorType =
+    RollIndicatorType.enhanced;
 
   @property({type: Number}) value = 0;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/roll-indicator/roll-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/roll-indicator/roll-indicator.ts
@@ -64,7 +64,7 @@ let nextTrackClipId = 0;
  */
 @customElement('obc-roll-indicator')
 export class ObcRollIndicator extends LitElement {
-  @property({type: String}) type: string = RollIndicatorType.enhanced;
+  @property({type: String}) type: RollIndicatorType = RollIndicatorType.enhanced;
 
   @property({type: Number}) value = 0;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rot-indicator/rot-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rot-indicator/rot-indicator.ts
@@ -12,7 +12,7 @@ export enum RotIndicatorType {
 @customElement('obc-rot-indicator')
 export class ObcRotIndicator extends LitElement {
   @property({type: String})
-  type: string = RotIndicatorType.radial;
+  type: RotIndicatorType = RotIndicatorType.radial;
 
   /**
    * Measured rate of turn in degrees per minute (positive = starboard).

--- a/packages/openbridge-webcomponents/src/navigation-instruments/rudder-indicator/rudder-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/rudder-indicator/rudder-indicator.ts
@@ -261,7 +261,8 @@ export class ObcRudderIndicator extends LitElement {
 
   @property({type: Number}) setpoint = 0;
 
-  @property({type: String}) state: string = RudderIndicatorState.InCommand;
+  @property({type: String}) state: RudderIndicatorState =
+    RudderIndicatorState.InCommand;
 
   @property({type: Boolean}) hasSilhouette = false;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/speed-indicator/speed-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/speed-indicator/speed-indicator.ts
@@ -46,7 +46,7 @@ const SHIP_PATH_D = 'M0.5 15.5V5Q0.5 2.95 3 0.5Q5.5 2.95 5.5 5V15.5H0.5Z';
 @customElement('obc-speed-indicator')
 export class ObcSpeedIndicator extends LitElement {
   @property({type: String})
-  type: string = SpeedIndicatorType.Needle;
+  type: SpeedIndicatorType = SpeedIndicatorType.Needle;
 
   @property({type: Number}) speed: number = 0;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/wind-indicator/wind-indicator.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/wind-indicator/wind-indicator.ts
@@ -182,11 +182,13 @@ const LABELED_ARROW_TPL = svg`
  */
 @customElement('obc-wind-indicator')
 export class ObcWindIndicator extends LitElement {
-  @property({type: String}) type: string = WindIndicatorType.arrow;
+  @property({type: String}) type: WindIndicatorType = WindIndicatorType.arrow;
 
-  @property({type: String}) direction: string = WindIndicatorDirection.true;
+  @property({type: String}) direction: WindIndicatorDirection =
+    WindIndicatorDirection.true;
 
-  @property({type: String}) priority: string = WindIndicatorPriority.regular;
+  @property({type: String}) priority: WindIndicatorPriority =
+    WindIndicatorPriority.regular;
 
   @property({type: Number}) level = 0;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type safety for navigation instrument component properties by using enum-based types instead of generic strings. This strengthens the public API type definitions and provides better IDE autocomplete and type-checking support for developers without changing runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ocean-Industries-Concept-Lab/openbridge-webcomponents/pull/876)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->