### PR TITLE
fix(message-menu-item): don't wrap time

### DIFF
--- a/packages/openbridge-webcomponents/src/components/message-menu-item/message-menu-item.css
+++ b/packages/openbridge-webcomponents/src/components/message-menu-item/message-menu-item.css
@@ -88,11 +88,8 @@
     gap: var(--app-components-message-menu-item-label-spacing);
 
     color: var(--element-neutral-color);
-
-    .day,
-    .time {
-      @mixin font-label;
-    }
+    white-space: nowrap;
+    text-wrap: nowrap;
   }
 
   .chevron {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date text wrapping in the message menu item component to ensure dates display on a single line without breaking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->