### PR TITLE
fix(automation-tank)!: remove @ignition JSDoc tags, default positioning to button

### DIFF
--- a/packages/openbridge-webcomponents/src/automation/automation-tank/automation-tank.ts
+++ b/packages/openbridge-webcomponents/src/automation/automation-tank/automation-tank.ts
@@ -126,10 +126,6 @@ export interface TankReadoutItem {
  * @slot alert-icon - Custom icon for the alert frame.
  * @slot alert-label - Label for the alert frame.
  * @slot alert-timer - Timer for the alert frame.
- *
- * @ignition-base-height: 173px
- * @ignition-base-width: 168px
- * @ignition-center-horizontal
  */
 @customElement('obc-automation-tank')
 export class ObcAutomationTank extends LitElement {
@@ -143,12 +139,12 @@ export class ObcAutomationTank extends LitElement {
   @property({type: Boolean, reflect: true}) compact: boolean = false;
   /**
    * Host positioning model — see `TankPositioning` for details. Defaults to
-   * `point` for backward compatibility (fixed default dimensions + P&ID
-   * top-center anchor). Set to `button` to make the host fill its parent
-   * container (100% × 100%) with no anchor offset.
+   * `button` (host fills parent container, 100% × 100%, no anchor offset).
+   * Set to `point` for the legacy P&ID canvas mode (fixed default dimensions
+   * + top-center anchor offset).
    */
   @property({type: String, reflect: true}) positioning: TankPositioning =
-    TankPositioning.point;
+    TankPositioning.button;
   /**
    * Static (display-only) variant. Always rendered at the compact size; the
    * inner chart/bar is hidden, the bordered area is filled with


### PR DESCRIPTION
## Summary\n\n- Fjerner `@ignition-base-height`, `@ignition-base-width` og `@ignition-center-horizontal` JSDoc-tags fra `obc-automation-tank`-klassen\n- Endrer default-verdi for `positioning`-property fra `point` til `button`\n- Oppdaterer JSDoc-kommentaren for `positioning`-property tilsvarende\n\n## Changes\n\n**`automation-tank.ts`**\n- Removed three `@ignition-*` annotations from the class-level JSDoc block\n- Changed `TankPositioning.point` → `TankPositioning.button` as the default value for `positioning`\n- Updated the `positioning` property JSDoc to reflect the new default (`button`) and document `point` as the legacy P&ID canvas mode\n\n## Test plan\n\n- [ ] Verify `obc-automation-tank` renders with `positioning=\"button\"` by default (fills parent container)\n- [ ] Verify explicitly passing `positioning=\"point\"` still works (P&ID anchor mode)\n- [ ] Check Storybook stories still render correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_016pWaSPPxA54Qefj7JmdxYW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default positioning mode for automation tank component from `point` to `button` mode.

* **Documentation**
  * Updated positioning property documentation to clarify the differences between available modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->