### PR TITLE
refactor!: rename alert badge `aggregate` option to `combine`

### DIFF
--- a/packages/openbridge-webcomponents/src/components/navigation-item-group/navigation-item-group.ts
+++ b/packages/openbridge-webcomponents/src/components/navigation-item-group/navigation-item-group.ts
@@ -111,7 +111,7 @@ export class ObcNavigationItemGroup extends LitElement {
   /**
    * Per-severity alert counts shown as trailing badge(s) on the group header
    * (Tree variant only). Forwarded to the underlying `obc-tree-navigation-item`;
-   * typically `{aggregate: true, ...}` so the header totals the rows beneath it.
+   * typically `{combine: true, ...}` so the header totals the rows beneath it.
    * See {@link TreeNavigationItemAlerts}.
    */
   @property({type: Object}) alerts?: TreeNavigationItemAlerts;

--- a/packages/openbridge-webcomponents/src/components/navigation-menu/navigation-menu.stories.ts
+++ b/packages/openbridge-webcomponents/src/components/navigation-menu/navigation-menu.stories.ts
@@ -269,7 +269,7 @@ export const Tree: Story = {
           hasIcon
           defaultOpen
           .alerts=${{
-            aggregate: true,
+            combine: true,
             countLevelCritical: 1,
             countLevelHigh: 1,
             countLevelMedium: 2,
@@ -283,7 +283,7 @@ export const Tree: Story = {
             defaultOpen
             terminalType="aggregated-header"
             .alerts=${{
-              aggregate: true,
+              combine: true,
               countLevelCritical: 1,
               countLevelHigh: 1,
             }}
@@ -308,7 +308,7 @@ export const Tree: Story = {
           <obc-navigation-item-group
             label="Bridge"
             hasIcon
-            .alerts=${{aggregate: true, countLevelMedium: 2, countLevelLow: 1}}
+            .alerts=${{combine: true, countLevelMedium: 2, countLevelLow: 1}}
           >
             <obi-placeholder slot="icon"></obi-placeholder>
             <obc-navigation-item

--- a/packages/openbridge-webcomponents/src/components/tree-navigation-group/tree-navigation-group.ts
+++ b/packages/openbridge-webcomponents/src/components/tree-navigation-group/tree-navigation-group.ts
@@ -85,7 +85,7 @@ export class ObcTreeNavigationGroup extends LitElement {
   /**
    * Per-severity alert counts shown as trailing badge(s) on the header row.
    * Forwarded verbatim to the header `<obc-tree-navigation-item>` — typically a
-   * group sets `{aggregate: true, ...}` so its header shows one badge totalling
+   * group sets `{combine: true, ...}` so its header shows one badge totalling
    * the alerts of the rows beneath it. See {@link TreeNavigationItemAlerts}.
    */
   @property({type: Object}) alerts?: TreeNavigationItemAlerts;

--- a/packages/openbridge-webcomponents/src/components/tree-navigation-item/tree-navigation-item.stories.ts
+++ b/packages/openbridge-webcomponents/src/components/tree-navigation-item/tree-navigation-item.stories.ts
@@ -101,7 +101,7 @@ export const WithAlertBadge: Story = {
 };
 
 /**
- * Several severities at once. With `aggregate` unset, each non-zero count
+ * Several severities at once. With `combine` unset, each non-zero count
  * renders its own badge, ordered most to least severe and spaced by
  * `var(--app-components-alert-counter-item-badge-spacing)`.
  */
@@ -117,14 +117,14 @@ export const MultipleAlertBadges: Story = {
 };
 
 /**
- * The same counts as `MultipleAlertBadges`, but `aggregate: true` collapses them
+ * The same counts as `MultipleAlertBadges`, but `combine: true` collapses them
  * into one badge: the number is the combined total (18) and the style is the
  * highest category present (level-critical).
  */
 export const AggregatedAlertBadge: Story = {
   args: {
     alerts: {
-      aggregate: true,
+      combine: true,
       countLevelCritical: 1,
       countLevelHigh: 3,
       countLevelMedium: 12,

--- a/packages/openbridge-webcomponents/src/components/tree-navigation-item/tree-navigation-item.ts
+++ b/packages/openbridge-webcomponents/src/components/tree-navigation-item/tree-navigation-item.ts
@@ -50,13 +50,13 @@ export enum TreeTerminalType {
  * `caution`. Badges are ordered and aggregated by the shared
  * `ALERT_SEVERITY_PRIORITY` ranking, most to least severe.
  *
- * Set `aggregate` to collapse the counts into a single badge showing the total,
+ * Set `combine` to collapse the counts into a single badge showing the total,
  * styled as the highest category present; otherwise one badge is rendered per
  * non-zero count.
  */
 export interface TreeNavigationItemAlerts {
   /** Collapse all counts into one badge: total count, highest-severity style. */
-  aggregate?: boolean;
+  combine?: boolean;
   /** Number of level-critical alerts. */
   countLevelCritical?: number;
   /** Number of alarm alerts. */
@@ -103,7 +103,7 @@ export interface TreeNavigationItemAlerts {
  *   per-severity count map with one field per level severity (critical, high,
  *   medium, low, diagnostic). By default each non-zero count renders its own
  *   badge, ordered most to least severe by `ALERT_SEVERITY_PRIORITY`; set
- *   `alerts.aggregate` to instead show a single badge with the combined total,
+ *   `alerts.combine` to instead show a single badge with the combined total,
  *   styled as the highest category present.
  * - **Checked state:** `checked` highlights the current selection using the
  *   amplified elevation style. A checked row is the current item and is not
@@ -183,7 +183,7 @@ export class ObcTreeNavigationItem extends LitElement {
    * Per-severity alert counts for the row's trailing badge(s). Omit (or leave
    * every count at 0) for a row with no alerts. See {@link TreeNavigationItemAlerts}.
    *
-   * - When `aggregate` is true, a single badge is shown: its number is the sum
+   * - When `combine` is true, a single badge is shown: its number is the sum
    *   of all counts and its severity is the highest category present
    *   (critical → alarm → warning → caution).
    * - Otherwise one badge is shown per count greater than 0, ordered most to
@@ -209,7 +209,7 @@ export class ObcTreeNavigationItem extends LitElement {
    * severity order, ranked by `ALERT_SEVERITY_PRIORITY`.
    *
    * - No `alerts`, or every count 0 → no badges.
-   * - `aggregate` → a single pair: the summed count typed as the highest
+   * - `combine` → a single pair: the summed count typed as the highest
    *   category that has any alerts.
    * - Otherwise → one pair per count greater than 0.
    */
@@ -226,12 +226,12 @@ export class ObcTreeNavigationItem extends LitElement {
       [AlertType.LevelLow]: alerts.countLevelLow ?? 0,
       [AlertType.LevelDiagnostic]: alerts.countLevelDiagnostic ?? 0,
     };
-    // Order (and, when aggregating, rank) by the shared severity priority,
+    // Order (and, when combining, rank) by the shared severity priority,
     // keeping only the severities this component exposes.
     const ranked = ALERT_SEVERITY_PRIORITY.filter(
       (type) => type in countByType
     ).map((type) => ({type, count: countByType[type] ?? 0}));
-    if (alerts.aggregate) {
+    if (alerts.combine) {
       const total = ranked.reduce((sum, b) => sum + b.count, 0);
       const highest = ranked.find((b) => b.count > 0);
       if (!highest) return [];

--- a/packages/openbridge-webcomponents/src/components/tree-navigation/tree-navigation.stories.ts
+++ b/packages/openbridge-webcomponents/src/components/tree-navigation/tree-navigation.stories.ts
@@ -24,14 +24,14 @@ const meta: Meta<typeof ObcTreeNavigation> = {
     <obc-tree-navigation>
       <obc-tree-navigation-group
         label="Vessel"
-        .alerts=${{aggregate: true, countLevelHigh: 3}}
+        .alerts=${{combine: true, countLevelHigh: 3}}
         expanded
       >
         ${iconIdToIconHtml('placeholder', {slot: 'icon'})}
         <obc-tree-navigation-group
           label="Engine room"
           expanded
-          .alerts=${{aggregate: true, countLevelHigh: 3}}
+          .alerts=${{combine: true, countLevelHigh: 3}}
           .terminalType=${TreeTerminalType.aggregatedHeader}
         >
           ${iconIdToIconHtml('placeholder', {slot: 'icon'})}
@@ -45,7 +45,7 @@ const meta: Meta<typeof ObcTreeNavigation> = {
           <obc-tree-navigation-group
             label="Auxiliary engine"
             expanded
-            .alerts=${{aggregate: true, countLevelHigh: 1}}
+            .alerts=${{combine: true, countLevelHigh: 1}}
           >
             ${iconIdToIconHtml('placeholder', {slot: 'icon'})}
             <obc-tree-navigation-item label="Fuel pump">
@@ -64,7 +64,7 @@ const meta: Meta<typeof ObcTreeNavigation> = {
           <obc-tree-navigation-group
             label="Cooling system"
             expanded
-            .alerts=${{aggregate: true, countLevelHigh: 1}}
+            .alerts=${{combine: true, countLevelHigh: 1}}
           >
             ${iconIdToIconHtml('placeholder', {slot: 'icon'})}
             <obc-tree-navigation-item
@@ -254,24 +254,24 @@ function sumAlerts(node: AlertNode): TreeNavigationItemAlerts {
 }
 
 /**
- * Render a node with every row using the given `aggregate` setting. Group rows
+ * Render a node with every row using the given `combine` setting. Group rows
  * carry the summed counts of their whole subtree; leaf rows carry their own
- * counts. With `aggregate` true each row collapses to a single total badge;
+ * counts. With `combine` true each row collapses to a single total badge;
  * with it false each row shows one badge per non-zero severity.
  */
-function renderAlertNode(node: AlertNode, aggregate: boolean): TemplateResult {
+function renderAlertNode(node: AlertNode, combine: boolean): TemplateResult {
   if (node.children) {
-    const alerts: TreeNavigationItemAlerts = {aggregate, ...sumAlerts(node)};
+    const alerts: TreeNavigationItemAlerts = {combine, ...sumAlerts(node)};
     return html`<obc-tree-navigation-group
       label=${node.label}
       expanded
       .alerts=${alerts}
     >
       ${iconIdToIconHtml('placeholder', {slot: 'icon'})}
-      ${node.children.map((child) => renderAlertNode(child, aggregate))}
+      ${node.children.map((child) => renderAlertNode(child, combine))}
     </obc-tree-navigation-group>`;
   }
-  const alerts = node.alerts ? {aggregate, ...node.alerts} : undefined;
+  const alerts = node.alerts ? {combine, ...node.alerts} : undefined;
   return html`<obc-tree-navigation-item label=${node.label} .alerts=${alerts}>
     ${iconIdToIconHtml('placeholder', {slot: 'icon'})}
   </obc-tree-navigation-item>`;
@@ -279,7 +279,7 @@ function renderAlertNode(node: AlertNode, aggregate: boolean): TemplateResult {
 
 /**
  * Alerts spread across leaves at several depths, every row with
- * `aggregate: true`. Each group header carries a single badge whose number is
+ * `combine: true`. Each group header carries a single badge whose number is
  * the sum of all alerts beneath it (child groups roll up into their parent in
  * turn), styled as the most severe category present — e.g. "Auxiliary engine"
  * totals 9 (1 critical + 6 medium + 2 low) and shows as critical, and "Vessel"
@@ -294,7 +294,7 @@ export const AggregatedAlertCounts: Story = {
 
 /**
  * The same tree and the same rolled-up totals, but every row with
- * `aggregate: false`: each row renders one badge per non-zero severity instead
+ * `combine: false`: each row renders one badge per non-zero severity instead
  * of a single combined badge. Group headers still sum their whole subtree —
  * e.g. "Auxiliary engine" shows separate critical (1), medium (6), and
  * low (2) badges.


### PR DESCRIPTION
## Summary

Renames the alert badge `aggregate` option to `combine`. This is the option on the navigation menu's alert badge that collapses the per-severity alert counts into a single badge showing the total (styled as the highest severity present).

## Changes

- Rename the `aggregate` field on the `TreeNavigationItemAlerts` interface to `combine`.
- Update its only consumer in `tree-navigation-item.ts` (`if (alerts.combine)`).
- Update doc comments referencing the option across `tree-navigation-item`, `navigation-item-group`, and `tree-navigation-group`.
- Update the Storybook stories (`navigation-menu`, `tree-navigation-item`, `tree-navigation`) to use `combine`.

## Out of scope

The separate `aggregated-header` terminal type marker and the event `aggregatedCount` concept are intentionally left unchanged — they are distinct features and not the alert badge option being renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMn78sw367Bb5uEv96r6A5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed alert badge configuration property from `aggregate` to `combine` across navigation components to clarify the behavior of collapsing multiple alert counts into a single badge displaying the highest severity level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->