### PR TITLE
fix: add new icon group for devices and sensors

### DIFF
--- a/packages/vue-demo/src/components/IconList.vue
+++ b/packages/vue-demo/src/components/IconList.vue
@@ -206,12 +206,7 @@ const groups = {
     'Command and users',
     'Chart targets'
   ],
-  'Devices & sensors': [
-    'Connectivity icons',
-    'Battery icons',
-    'Communication & sound',
-    'Sensors'
-  ],
+  'Devices & sensors': ['Connectivity icons', 'Battery icons', 'Communication & sound', 'Sensors'],
   'Weather & Environment icons': ['Forecast', 'General'],
   'Automation icons': [
     'Automation system',

--- a/packages/vue-demo/src/components/IconList.vue
+++ b/packages/vue-demo/src/components/IconList.vue
@@ -206,6 +206,12 @@ const groups = {
     'Command and users',
     'Chart targets'
   ],
+  'Devices & sensors': [
+    'Connectivity icons',
+    'Battery icons',
+    'Communication & sound',
+    'Sensors'
+  ],
   'Weather & Environment icons': ['Forecast', 'General'],
   'Automation icons': [
     'Automation system',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Devices & sensors** category to the icon browser, with subgroups for **Connectivity**, **Battery**, **Communication & sound**, and **Sensors**.
  * Updated icon grouping so matching icons are shown under the new category for easier browsing and selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->