### PR TITLE
test(readout): add LevelLowUnackedRectified alert-frame story

### DIFF
--- a/packages/openbridge-webcomponents/src/navigation-instruments/readout/readout.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/readout/readout.stories.ts
@@ -299,3 +299,16 @@ export const LevelCritical: Story = {
   },
   render: (args) => renderComponent(args as ObcReadout),
 };
+
+export const LevelLowUnackedRectified: Story = {
+  args: {
+    value: 42,
+    label: 'RPM',
+    unit: 'rpm',
+    alert: {
+      status: 'level-low',
+      mode: 'unacked-rectified',
+    },
+  },
+  render: (args) => renderComponent(args as ObcReadout),
+};


### PR DESCRIPTION
## Summary

The `<obc-readout>` component already wraps its content in an alert frame via `wrapWithAlertFrame(this.alert, ...)` — the same mechanism as `<obc-readout-list-item>`. Unlike readout-list-item (which fills full width when wrapped, see #1001), readout keeps the alert frame at `fullWidth=false`, so no change to `readout.ts` was needed.

This PR adds a `LevelLowUnackedRectified` story for parity with the readout-list-item alert-frame stories, so the readout alert-frame appearance is covered by the visual snapshots alongside the existing `Alarm` and `LevelCritical` stories.

## Changes
- Add `LevelLowUnackedRectified` story (`level-low` / `unacked-rectified`) to `readout.stories.ts`.

## Snapshots
A new baseline (`level-low-unacked-rectified-auto.png`) needs to be rendered for the added story. Since the linux baselines are produced inside the CI Docker image, comment `/update-snapshots` on this PR to generate and push it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019wR9p9f8asxSMxjWXtfW9a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Storybook example for the readout component showing an RPM alert state with a low-level, unacknowledged rectified condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->