### PR TITLE
build: pin node version to fix node regression

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Build vue-demo
         run: cd packages/vue-demo && npm run build
 
+      # Node 24.17.0 has an HTTP keep-alive socket-reuse bug that causes
+      # firebase-tools to hit "premature close" errors against googleapis.com,
+      # leading to false-negative deploy failures. Pin to the patched 24.18.0.
+      - name: Pin Node for Firebase deploy
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.18.0"
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
@@ -71,6 +79,14 @@ jobs:
         run: cd packages/openbridge-webcomponents && npm run build-storybook
         env:
           NODE_OPTIONS: --max-old-space-size=6144
+
+      # Node 24.17.0 has an HTTP keep-alive socket-reuse bug that causes
+      # firebase-tools to hit "premature close" errors against googleapis.com,
+      # leading to false-negative deploy failures. Pin to the patched 24.18.0.
+      - name: Pin Node for Firebase deploy
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.18.0"
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request-deploy.yml
+++ b/.github/workflows/firebase-hosting-pull-request-deploy.yml
@@ -83,6 +83,14 @@ jobs:
       - name: "Unzip artifact"
         run: cd packages/openbridge-webcomponents/ && mkdir -p storybook-static && unzip storybook.zip -d storybook-static
 
+      # Node 24.17.0 has an HTTP keep-alive socket-reuse bug that causes
+      # firebase-tools to hit "premature close" errors against googleapis.com,
+      # leading to false-negative deploy failures. Pin to the patched 24.18.0.
+      - name: Pin Node for Firebase deploy
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.18.0"
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
         id: firebase
         with:
@@ -197,6 +205,14 @@ jobs:
 
       - name: "Unzip artifact"
         run: cd packages/vue-demo/ && mkdir -p dist && unzip vue-demo.zip -d dist
+
+      # Node 24.17.0 has an HTTP keep-alive socket-reuse bug that causes
+      # firebase-tools to hit "premature close" errors against googleapis.com,
+      # leading to false-negative deploy failures. Pin to the patched 24.18.0.
+      - name: Pin Node for Firebase deploy
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.18.0"
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         id: firebase


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized Firebase Hosting deployments by pinning Node.js to a newer version, reducing false deployment failures caused by a known runtime issue.
  * Improved reliability for both merge and pull request deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->