### PR TITLE
fix(automation-button): remove activated icon-holder background override

### DIFF
--- a/packages/openbridge-webcomponents/src/automation/automation-button/automation-button.css
+++ b/packages/openbridge-webcomponents/src/automation/automation-button/automation-button.css
@@ -247,11 +247,6 @@
   background: var(--automation-button-static-background-color);
 }
 
-.activated .icon-holder {
-  border-color: var(--normal-activated-border-color);
-  background: var(--normal-activated-background-color);
-}
-
 .alert-frame {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary

The `activated` prop PR (#1026) added a CSS rule that changed the icon holder's border and background color in the activated state. This caused a visual regression — the icon holder should keep its normal background when activated.

This PR removes that override:

```css
.activated .icon-holder {
  border-color: var(--normal-activated-border-color);
  background: var(--normal-activated-background-color);
}
```

## Snapshots

The `switch-activated` and `valve-activated` visual baselines added in #1026 reflect the old (buggy) background. They need to be re-rendered against the corrected CSS via the `/update-snapshots` workflow.


---
_Generated by [Claude Code](https://claude.ai/code/session_015tZgr9X7QRphLokDGBu5D5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted button styling by removing a specific activated-state icon appearance, resulting in a simpler visual state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->