### PR TITLE
fix(watch): clamp tick-label scale to avoid first-paint Infinity errors

### DIFF
--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/tickmark.spec.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/tickmark.spec.ts
@@ -1,0 +1,99 @@
+import {describe, it, expect} from 'vitest';
+import type {SVGTemplateResult} from 'lit';
+import {tickmark, TickmarkType, TickmarkStyle} from './tickmark.js';
+
+/**
+ * Collect every numeric interpolated value from a `tickmark()` result without
+ * rendering it. `tickmark()` returns Lit `SVGTemplateResult`s (or an array of
+ * them); the interpolated `x`/`y`/coordinate values live on `.values`. This
+ * lets us assert the geometry is finite in a plain Node environment — no DOM.
+ */
+function numericValues(
+  result: SVGTemplateResult | SVGTemplateResult[]
+): number[] {
+  const templates = Array.isArray(result) ? result : [result];
+  const numbers: number[] = [];
+  for (const template of templates) {
+    for (const value of template.values) {
+      if (typeof value === 'number') {
+        numbers.push(value);
+      }
+    }
+  }
+  return numbers;
+}
+
+describe('tickmark label positioning', () => {
+  // On first paint the element is not laid out yet, so obc-watch computes a
+  // scale of 0. A `textOnly` tick still renders a <text>, and dividing by a
+  // zero scale used to yield x/y of ±Infinity — which the browser rejects with
+  // `<text> attribute x: Expected length, "-Infinity"` (issue #1032).
+  it('keeps the zero-value textOnly label finite when the scale is 0', () => {
+    const result = tickmark(-90, {
+      size: TickmarkType.textOnly,
+      style: TickmarkStyle.regular,
+      scale: 0,
+      text: '0',
+      inside: false,
+      textRadius: 184,
+      maxDigits: 1,
+    });
+
+    for (const value of numericValues(result)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  it('keeps labelled ticks finite for a zero scale (inside and outside)', () => {
+    for (const inside of [false, true]) {
+      const result = tickmark(45, {
+        size: TickmarkType.primary,
+        style: TickmarkStyle.regular,
+        scale: 0,
+        text: '50',
+        inside,
+        textRadius: 184,
+        maxDigits: 2,
+      });
+
+      for (const value of numericValues(result)) {
+        expect(Number.isFinite(value)).toBe(true);
+      }
+    }
+  });
+
+  it('keeps rotated labels finite for a zero scale', () => {
+    const result = tickmark(120, {
+      size: TickmarkType.primary,
+      style: TickmarkStyle.regular,
+      scale: 0,
+      text: '12',
+      inside: false,
+      textRadius: 184,
+      rotation: 120,
+      maxDigits: 2,
+    });
+
+    for (const value of numericValues(result)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  it('does not distort geometry for a valid scale', () => {
+    // A settled scale must be untouched: the outside zero tick at -90° sits on
+    // the negative-x axis, so its x is finite and negative and y is ~0.
+    const result = tickmark(-90, {
+      size: TickmarkType.textOnly,
+      style: TickmarkStyle.regular,
+      scale: 1,
+      text: '0',
+      inside: false,
+      textRadius: 184,
+      maxDigits: 1,
+    });
+
+    const numbers = numericValues(result);
+    expect(numbers.every(Number.isFinite)).toBe(true);
+    expect(numbers.some((n) => n < -100)).toBe(true);
+  });
+});

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/tickmark.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/tickmark.ts
@@ -64,14 +64,15 @@ export function tickmark(
     endLabelsMaxMin?: boolean;
   }
 ): SVGTemplateResult | SVGTemplateResult[] {
-  // check if scale is not infinite
-  if (scale === Infinity || scale < 0) {
-    throw new Error('Tick scale is not valid');
-  }
+  // Before layout settles the caller can pass a scale of 0 (or a non-finite
+  // value). Label offsets are computed as `px / scale`, so a 0 scale would emit
+  // ±Infinity coordinates that the browser rejects. Fall back to a 1:1 scale
+  // until a real one is available (issue #1032).
+  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
   const rOff = radiusOffset;
   let innerRadius: number;
   let outerRadius: number;
-  textRadius = textRadius + (3 / scale + 3) * (inside ? -1 : 1);
+  textRadius = textRadius + (3 / safeScale + 3) * (inside ? -1 : 1);
   const rad = (angle * Math.PI) / 180;
   if (size === TickmarkType.primary) {
     innerRadius = 328 / 2 + rOff;
@@ -90,7 +91,13 @@ export function tickmark(
     outerRadius = 336 / 2 + rOff;
   } else {
     return [
-      textSvg(text ?? '', {angle, inside, scale, textRadius, endLabelsMaxMin}),
+      textSvg(text ?? '', {
+        angle,
+        inside,
+        scale: safeScale,
+        textRadius,
+        endLabelsMaxMin,
+      }),
     ];
   }
 
@@ -121,11 +128,17 @@ export function tickmark(
     if (rotation === undefined) {
       return [
         tick,
-        textSvg(text, {angle, inside, scale, textRadius, endLabelsMaxMin}),
+        textSvg(text, {
+          angle,
+          inside,
+          scale: safeScale,
+          textRadius,
+          endLabelsMaxMin,
+        }),
       ];
     } else {
       const newRadius =
-        textRadius + ((4 / scale + 5) * (inside ? -1 : 1) * maxDigits) / 2;
+        textRadius + ((4 / safeScale + 5) * (inside ? -1 : 1) * maxDigits) / 2;
       const textX = Math.sin(rad) * newRadius;
       const textY = -Math.cos(rad) * newRadius;
       return [

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
@@ -690,8 +690,13 @@ export class ObcWatch extends LitElement {
       }
     }
     const scale = Math.min(clientWidth / width, clientHeight / height);
-    if (scale === Infinity || scale < 0) {
-      throw new Error('Watch scale is not valid');
+    // On first paint the element and its parent can both still be zero-sized, so
+    // the scale is 0 (or non-finite). That value flows into `px / scale` label
+    // math and yields ±Infinity coordinates the browser rejects. Fall back to a
+    // 1:1 scale until a real size is available; the ResizeController re-renders
+    // with the true scale once the element is laid out (issue #1032).
+    if (!Number.isFinite(scale) || scale <= 0) {
+      return 1;
     }
     return scale;
   }


### PR DESCRIPTION
## Summary

Fixes #1032 — on first paint, `obc-speed-gauge` and `obc-instrument-radial` logged SVG errors from tick-label positioning:

```
Error: <text> attribute x: Expected length, "-Infinity".
Error: <text> attribute y: Expected length, "Infinity".
```

### Root cause

Before layout settles, `obc-watch` and its parent can both report zero size, so `getScale()` computed `Math.min(0 / width, 0 / height) = 0`. The guard rejected `Infinity` and negatives but **let `0` through**. That `0` flowed into the tick-label positioning math (`px / scale`), producing `<text>` coordinates of `±Infinity`, which the browser rejects.

It affected **every `obc-watch`-based radial instrument** because they always emit a `textOnly` zero-value tick, which renders a `<text>` positioned via `/scale` regardless of `showLabels`. The `ResizeController` re-renders with the true scale once the element is laid out, so the error was transient (first paint only).

### Fix (shared rendering core — covers all radial instruments)

- **`watch.ts` `getScale()`** — fall back to a 1:1 scale when the computed scale isn't finite-and-positive, instead of returning `0`. This also protects the other `/scale` consumers (compass labels, north arrow).
- **`tickmark.ts`** — clamp an invalid scale to `1` locally (`safeScale`, defense-in-depth) so the shared helper never emits non-finite coordinates for any caller.

For a valid scale the clamped value is identical, so rendered output and visual snapshots are unchanged.

### Tests

Adds `tickmark.spec.ts`, a regression spec asserting `tickmark()` never emits non-finite coordinates for a zero scale (RED before the fix, GREEN after). It inspects the Lit template's `.values`, so it needs no DOM and runs in either environment.

### Verification

- ✅ New spec: RED → GREEN
- ✅ `npm run typecheck`
- ✅ `npm run lint` (lit-analyzer: 0 problems in 2719 files; eslint: 0 errors)
- ✅ `prettier --check`

Visual snapshot tests were not run locally (unrelated browser-harness flakiness in the dev container). They are safe by construction — only the degenerate zero-size case changes — but should be confirmed in CI.

### Follow-up

`watch-flat.ts` has the same latent pattern via its own independent scale computation (`const scale = this.clientWidth / width`) and is **not** covered by this fix — tracked in #1041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch navigation rendering when the available size is zero or otherwise invalid.
  * Prevented invalid coordinate calculations from producing non-finite values, so labels and tick marks render more reliably.
  * Ensured tick mark geometry stays valid across text-only, inside/outside, rotated, and standard scale configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
