### PR TITLE
fix: document component properties inline instead of class-level @property tags (#1043)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Key points:
 3. **Usage Guidelines** — when and how to use the component; contrast with similar components.
 4. **Slots** — table of slot names, conditions, and purposes.
 5. **Events** — `@fires` tags for every custom event.
-6. **No `@property` tags** in the JSDoc block — properties are documented inline above their field declarations.
+6. **No `@property` tags** in the class JSDoc block — properties are documented inline above their field declarations. A class-level `@property` tag **overrides** the inline doc in `custom-elements.json` and can inject a **ghost member** for a property that does not exist (issue #1043). Enforced by `npm run lint:slots`. (Documenting a CSS-only attribute that has no backing `@property` field via `@attr`/`@attribute` in the class block is allowed — there is no field to annotate.)
 7. **Tone:** Do NOT mention "maritime", "industrial", "bridge", or domain qualifiers; keep text domain-agnostic.
 8. If purpose is unclear, insert `**TODO(designer)**` instead of guessing.
 9. **`@availableWhen` for conditional properties** — see below.

--- a/packages/openbridge-webcomponents/script/check-slot-event-docs.ts
+++ b/packages/openbridge-webcomponents/script/check-slot-event-docs.ts
@@ -31,6 +31,11 @@
  * - **Empty description (warning):** a `@slot`/`@fires` tag with only a name and
  *   no descriptive text. These become blank cells in the manifest / Storybook
  *   controls; warnings do not fail CI.
+ * - **Class-level `@property`/`@attr` tag (error):** properties must be documented
+ *   inline above their field declarations (AGENTS.md §3.6). A tag in the class
+ *   JSDoc block overrides the inline doc and can inject a ghost member for a
+ *   non-existent property (issue #1043). A short allowlist covers documented
+ *   exceptions (property-injecting mixins, one legacy chart-base tag).
  *
  * There is deliberately no phantom-`@fires` *error*: unlike slots (which must be
  * a `<slot>` element in the component's own shadow DOM), a documented event may
@@ -301,6 +306,32 @@ async function run(): Promise<void> {
           message: `@fires ${tag.name} has no description`,
         });
       }
+    }
+  }
+
+  // Class-level @property / @attr JSDoc tags (AGENTS.md §3.6): properties must be
+  // documented inline above their field declarations. A class-level tag overrides
+  // the inline doc and can inject a ghost member for a property that does not
+  // exist (issue #1043). Allowlisted files are documented exceptions: mixins that
+  // inject properties into consumers, and one legacy `fill` tag on the chart base.
+  const PROPERTY_TAG_ALLOWLIST = [
+    'svghelpers/setpoint-mixin.ts',
+    'svghelpers/setpoint-bundle.ts',
+    'building-blocks/chart-line/chart-line-base.ts',
+  ];
+  // Only `@property` is flagged. `@attr`/`@attribute` in a class block is the
+  // legitimate way to document a CSS-only attribute that has no backing
+  // `@property` field (e.g. slider's `hugcontainer`), so it is not an error.
+  const propTagRe = /^[ \t]*\*[ \t]*@property\b/gm;
+  for (const rel of files.sort()) {
+    if (PROPERTY_TAG_ALLOWLIST.some((a) => rel.endsWith(a))) continue;
+    const source = fs.readFileSync(path.join(cwd, rel), 'utf8');
+    const matches = source.match(propTagRe);
+    if (matches && matches.length > 0) {
+      errors.push({
+        file: rel,
+        message: `has ${matches.length} class-level @property JSDoc tag(s) — document each property inline above its field declaration instead (AGENTS.md §3.6; these override inline docs and can create ghost manifest members)`,
+      });
     }
   }
 

--- a/packages/openbridge-webcomponents/script/check-slot-event-docs.ts
+++ b/packages/openbridge-webcomponents/script/check-slot-event-docs.ts
@@ -31,11 +31,13 @@
  * - **Empty description (warning):** a `@slot`/`@fires` tag with only a name and
  *   no descriptive text. These become blank cells in the manifest / Storybook
  *   controls; warnings do not fail CI.
- * - **Class-level `@property`/`@attr` tag (error):** properties must be documented
+ * - **Class-level `@property` tag (error):** properties must be documented
  *   inline above their field declarations (AGENTS.md §3.6). A tag in the class
  *   JSDoc block overrides the inline doc and can inject a ghost member for a
  *   non-existent property (issue #1043). A short allowlist covers documented
- *   exceptions (property-injecting mixins, one legacy chart-base tag).
+ *   exceptions (property-injecting mixins, one legacy chart-base tag). A
+ *   class-level `@attr`/`@attribute` that documents a CSS-only attribute with
+ *   no backing `@property` field is allowed and is not flagged.
  *
  * There is deliberately no phantom-`@fires` *error*: unlike slots (which must be
  * a `<slot>` element in the component's own shadow DOM), a documented event may
@@ -322,7 +324,9 @@ async function run(): Promise<void> {
   // Only `@property` is flagged. `@attr`/`@attribute` in a class block is the
   // legitimate way to document a CSS-only attribute that has no backing
   // `@property` field (e.g. slider's `hugcontainer`), so it is not an error.
-  const propTagRe = /^[ \t]*\*[ \t]*@property\b/gm;
+  // Matches both the multi-line (` * @property`) and single-line
+  // (`/** @property`) JSDoc block-comment forms.
+  const propTagRe = /^[ \t]*(?:\/\*\*|\*)[ \t]*@property\b/gm;
   for (const rel of files.sort()) {
     if (PROPERTY_TAG_ALLOWLIST.some((a) => rel.endsWith(a))) continue;
     const source = fs.readFileSync(path.join(cwd, rel), 'utf8');

--- a/packages/openbridge-webcomponents/src/bars-graphs/donut-chart/donut-chart.ts
+++ b/packages/openbridge-webcomponents/src/bars-graphs/donut-chart/donut-chart.ts
@@ -208,7 +208,7 @@ export class ObcDonutChart extends LitElement {
   @property({type: Boolean, reflect: true})
   showDebugOverlay = false;
 
-  /** Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
+  /** Fixed height of the chart in pixels (determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
   @property({type: Number, reflect: true})
   fixedHeight = 320;
 

--- a/packages/openbridge-webcomponents/src/bars-graphs/donut-chart/donut-chart.ts
+++ b/packages/openbridge-webcomponents/src/bars-graphs/donut-chart/donut-chart.ts
@@ -138,75 +138,77 @@ export type DonutChartDataItem = {
  * </script>
  * ```
  *
- * @property {Array<{label: string, value: number}>} data - Chart data segments (set via JavaScript)
- * @property {string[]} colors - Custom segment colors (set via JavaScript) with fallback to theme palette
- * @property {boolean} half - Whether to display as half-circle (180°) or full circle (360°), default: false
- * @property {boolean} showOuterLabels - Show outer labels, default: false
- * @property {boolean} showUnit - Whether to show unit in labels, default: false
- * @property {string} outerLabelUnit - Unit string to append to outer labels, default: "%"
- * @property {number} outerLabelMaxLength - Maximum character length for labels before trim (0 = no limit), default: 0
- * @property {number} outerLabelDecimalPlaces - Number of decimal places in labels, default: 0
- * @property {string} centerReadoutLabel - Text label shown below the center total value, default: "Total"
- * @property {string} centerReadoutUnit - Unit string shown inline after the label in the center readout, default: "%"
- * @property {number} max - Maximum value for calculating remaining empty sector, default: 100
- * @property {number} thickness - Donut ring thickness in pixels, default: 24
- * @property {boolean} showDebugOverlay - Show debug overlay for development, default: false
- * @property {number} fixedHeight - Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments.
- * @property {boolean} legend - Whether to display the legend below the chart, default: false
  * @beta
  */
 @customElement('obc-donut-chart')
 export class ObcDonutChart extends LitElement {
+  /** Chart data segments (set via JavaScript) */
   @property({type: Array, attribute: false})
   data: DonutChartDataItem[] = [];
 
+  /** Custom segment colors (set via JavaScript) with fallback to theme palette */
   @property({type: Array, attribute: false})
   colors: string[] = [];
 
   @property({type: String})
   priority: Priority = Priority.regular;
 
+  /** Whether to display as half-circle (180°) or full circle (360°), default: false */
   @property({type: Boolean, reflect: true})
   half = false;
 
+  /** Show outer labels, default: false */
   @property({type: Boolean})
   showOuterLabels = false;
 
+  /** Whether to show unit in labels, default: false */
   @property({type: Boolean})
   showUnit = false;
 
+  /** Unit string to append to outer labels, default: "%" */
   @property({type: String})
   outerLabelUnit = '%';
 
-  /** @availableWhen showOuterLabels==true */
+  /**
+   * Maximum character length for labels before trim (0 = no limit), default: 0
+   * @availableWhen showOuterLabels==true
+   */
   @property({
     type: Number,
   })
   outerLabelMaxLength = 0;
 
+  /** Number of decimal places in labels, default: 0 */
   @property({
     type: Number,
   })
   outerLabelDecimalPlaces = 0;
 
+  /** Text label shown below the center total value, default: "Total" */
   @property({type: String})
   centerReadoutLabel = 'Total';
 
+  /** Unit string shown inline after the label in the center readout, default: "%" */
   @property({type: String})
   centerReadoutUnit = '%';
 
+  /** Maximum value for calculating remaining empty sector, default: 100 */
   @property({type: Number})
   max = 100;
 
+  /** Donut ring thickness in pixels, default: 24 */
   @property({type: Number})
   thickness = 24;
 
+  /** Whether to display the legend below the chart, default: false */
   @property({type: Boolean, reflect: true})
   legend = false;
 
+  /** Show debug overlay for development, default: false */
   @property({type: Boolean, reflect: true})
   showDebugOverlay = false;
 
+  /** Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
   @property({type: Number, reflect: true})
   fixedHeight = 320;
 

--- a/packages/openbridge-webcomponents/src/bars-graphs/pie-chart/pie-chart.ts
+++ b/packages/openbridge-webcomponents/src/bars-graphs/pie-chart/pie-chart.ts
@@ -156,59 +156,61 @@ export type PieChartDataItem = {
  * </script>
  * ```
  *
- * @property {Array<{label: string, value: number, children?: Array<{label: string, value: number}>}>} data - Chart data segments with optional children subsegments for sunburst mode (set via JavaScript)
- * @property {string[]} colors - Custom segment colors (set via JavaScript) with fallback to theme palette
- * @property {boolean} showOuterLabels - Show outer labels, default: false
- * @property {boolean} showUnit - Whether to show unit in labels, default: false
- * @property {boolean} sunburst - Enable sunburst mode with interactive children subsegments, default: false
- * @property {string} outerLabelUnit - Unit string to append to outer labels, default: "%"
- * @property {number} outerLabelMaxLength - Maximum character length for labels before trim (0 = no limit), default: 0
- * @property {number} outerLabelDecimalPlaces - Number of decimal places in labels, default: 0
- * @property {boolean} showDebugOverlay - Show debug overlay for development, default: false
- * @property {number} fixedHeight - Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments.
- * @property {boolean} legend - Whether to display the legend below the chart, default: false
  * @beta
  */
 @customElement('obc-pie-chart')
 export class ObcPieChart extends LitElement {
+  /** Chart data segments with optional children subsegments for sunburst mode (set via JavaScript). */
   @property({type: Array, attribute: false})
   data: PieChartDataItem[] = [];
 
+  /** Custom segment colors (set via JavaScript) with fallback to theme palette */
   @property({type: Array, attribute: false})
   colors: string[] = [];
 
   @property({type: String})
   priority: Priority = Priority.regular;
 
+  /** Show outer labels, default: false */
   @property({type: Boolean})
   showOuterLabels = false;
 
+  /** Whether to show unit in labels, default: false */
   @property({type: Boolean})
   showUnit = false;
 
+  /** Enable sunburst mode with interactive children subsegments, default: false */
   @property({type: Boolean})
   sunburst = false;
 
+  /** Unit string to append to outer labels, default: "%" */
   @property({type: String})
   outerLabelUnit = '%';
 
-  /** @availableWhen showOuterLabels==true */
+  /**
+   * Maximum character length for labels before trim (0 = no limit), default: 0
+   * @availableWhen showOuterLabels==true
+   */
   @property({
     type: Number,
   })
   outerLabelMaxLength = 0;
 
+  /** Number of decimal places in labels, default: 0 */
   @property({
     type: Number,
   })
   outerLabelDecimalPlaces = 0;
 
+  /** Whether to display the legend below the chart, default: false */
   @property({type: Boolean, reflect: true})
   legend = false;
 
+  /** Show debug overlay for development, default: false */
   @property({type: Boolean, reflect: true})
   showDebugOverlay = false;
 
+  /** Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
   @property({type: Number, reflect: true})
   fixedHeight = 320;
 

--- a/packages/openbridge-webcomponents/src/bars-graphs/pie-chart/pie-chart.ts
+++ b/packages/openbridge-webcomponents/src/bars-graphs/pie-chart/pie-chart.ts
@@ -210,7 +210,7 @@ export class ObcPieChart extends LitElement {
   @property({type: Boolean, reflect: true})
   showDebugOverlay = false;
 
-  /** Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
+  /** Fixed height of the chart in pixels (determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
   @property({type: Number, reflect: true})
   fixedHeight = 320;
 

--- a/packages/openbridge-webcomponents/src/bars-graphs/polar-chart/polar-chart.ts
+++ b/packages/openbridge-webcomponents/src/bars-graphs/polar-chart/polar-chart.ts
@@ -192,7 +192,7 @@ export class ObcPolarChart extends LitElement {
   /** Show outer labels, default: false */
   @property({type: Boolean})
   showOuterLabels = false;
-  /** Unit string to append to outer labels, default: "" */
+  /** Unit string to append to outer labels, default: "°" */
   @property({type: String})
   outerLabelUnit = '°';
   /**
@@ -205,7 +205,7 @@ export class ObcPolarChart extends LitElement {
   @property({type: Number})
   outerLabelDecimalPlaces = 0;
 
-  /** Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
+  /** Fixed height of the chart in pixels (determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
   @property({type: Number, reflect: true})
   fixedHeight = 320;
 

--- a/packages/openbridge-webcomponents/src/bars-graphs/polar-chart/polar-chart.ts
+++ b/packages/openbridge-webcomponents/src/bars-graphs/polar-chart/polar-chart.ts
@@ -158,27 +158,15 @@ export type PolarChartDataItem = {
  * </script>
  * ```
  *
- * @property {Array<{label: string, value: number}>} data - Chart data segments (set via JavaScript)
- * @property {string[]} colors - Custom segment colors (set via JavaScript) with fallback to theme palette
- * @property {boolean} monochrome - Use single color for all sectors (uses first color from array, default: false)
- * @property {boolean} discreteColorStops - Draw sectors as radial color bands from center outward using the colors array as threshold steps (default: false)
- * @property {boolean} trimToDiscreteStops - When true, visually trim sectors to the nearest discrete color band boundary. When false, show exact values with partial band fills (default: true)
- * @property {boolean} showSectorLabels - When true, display sector labels from data (e.g. "Sector A"). When false, display angle values (0°, 30°, etc.). Default: false
- * @property {boolean} showUnit - Whether to show unit in angle or outer labels, default: false
- * @property {boolean} showOuterLabels - Show outer labels, default: false
- * @property {string} outerLabelUnit - Unit string to append to outer labels, default: ""
- * @property {number} outerLabelMaxLength - Maximum character length for labels before trim (0 = no limit), default: 0
- * @property {number} outerLabelDecimalPlaces - Number of decimal places in labels, default: 0
- * @property {boolean} showDebugOverlay - Show debug overlay for development, default: false
- * @property {number} fixedHeight - Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments.
- * @property {boolean} legend - Whether to display the legend below the chart, default: false
  * @beta
  */
 @customElement('obc-polar-chart')
 export class ObcPolarChart extends LitElement {
+  /** Chart data segments (set via JavaScript) */
   @property({type: Array, attribute: false})
   data: PolarChartDataItem[] = [];
 
+  /** Custom segment colors (set via JavaScript) with fallback to theme palette */
   @property({type: Array, attribute: false}) colors: string[] = [];
 
   /** @internal */
@@ -187,30 +175,45 @@ export class ObcPolarChart extends LitElement {
   @property({type: String})
   priority: Priority = Priority.regular;
 
-  /** @availableWhen discreteColorStops==false */
+  /**
+   * Use single color for all sectors (uses first color from array, default: false)
+   * @availableWhen discreteColorStops==false
+   */
   @property({type: Boolean}) monochrome = false;
+  /** Draw sectors as radial color bands from center outward using the colors array as threshold steps (default: false) */
   @property({type: Boolean})
   discreteColorStops = false;
+  /** When true, display sector labels from data (e.g. "Sector A"). When false, display angle values (0°, 30°, etc.). Default: false */
   @property({type: Boolean})
   showSectorLabels = false; // Default: false (angles shown by default)
+  /** Whether to show unit in angle or outer labels, default: false */
   @property({type: Boolean})
   showUnit = false;
+  /** Show outer labels, default: false */
   @property({type: Boolean})
   showOuterLabels = false;
+  /** Unit string to append to outer labels, default: "" */
   @property({type: String})
   outerLabelUnit = '°';
-  /** @availableWhen showOuterLabels==true */
+  /**
+   * Maximum character length for labels before trim (0 = no limit), default: 0
+   * @availableWhen showOuterLabels==true
+   */
   @property({type: Number})
   outerLabelMaxLength = 0;
+  /** Number of decimal places in labels, default: 0 */
   @property({type: Number})
   outerLabelDecimalPlaces = 0;
 
+  /** Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
   @property({type: Number, reflect: true})
   fixedHeight = 320;
 
+  /** Whether to display the legend below the chart, default: false */
   @property({type: Boolean, reflect: true})
   legend = false;
 
+  /** Show debug overlay for development, default: false */
   @property({type: Boolean, reflect: true})
   showDebugOverlay = false;
 

--- a/packages/openbridge-webcomponents/src/bars-graphs/radial-bar-chart/radial-bar-chart.ts
+++ b/packages/openbridge-webcomponents/src/bars-graphs/radial-bar-chart/radial-bar-chart.ts
@@ -125,32 +125,32 @@ const RADIAL_BAR_WATCHED_PROP_NAMES = [
  * </script>
  * ```
  *
- * @property {number[]} data - Array of values for each ring (set via JavaScript)
- * @property {string[]} colors - Custom ring colors (set via JavaScript) with fallback to theme palette
- * @property {number} max - Maximum value for calculating remaining empty area, default: 100
- * @property {number} circumference - Arc span in degrees: 360 for full circle, 270 for 3/4 circle, default: 270
- * @property {boolean} showDebugOverlay - Show debug overlay for development, default: false
- * @property {number} fixedHeight - Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments.
- * @property {number} minRingThickness - Minimum thickness of each ring in pixels, excluding borders, default: 16
- * @property {boolean} legend - Whether to display the legend below the chart, default: false
  * @beta
  */
 @customElement('obc-radial-bar-chart')
 export class ObcRadialBarChart extends LitElement {
+  /** Array of values for each ring (set via JavaScript) */
   @property({type: Array, attribute: false}) data: number[] = [];
+  /** Custom ring colors (set via JavaScript) with fallback to theme palette */
   @property({type: Array, attribute: false}) colors: string[] = [];
   @property({type: String})
   priority: Priority = Priority.regular;
+  /** Maximum value for calculating remaining empty area, default: 100 */
   @property({type: Number})
   max = 100;
+  /** Arc span in degrees: 360 for full circle, 270 for 3/4 circle, default: 270 */
   @property({type: Number})
   circumference = 270;
+  /** Whether to display the legend below the chart, default: false */
   @property({type: Boolean, reflect: true})
   legend = false;
+  /** Show debug overlay for development, default: false */
   @property({type: Boolean, reflect: true})
   showDebugOverlay = false;
+  /** Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
   @property({type: Number, reflect: true})
   fixedHeight = 320;
+  /** Minimum thickness of each ring in pixels, excluding borders, default: 16 */
   @property({
     type: Number,
   })

--- a/packages/openbridge-webcomponents/src/bars-graphs/radial-bar-chart/radial-bar-chart.ts
+++ b/packages/openbridge-webcomponents/src/bars-graphs/radial-bar-chart/radial-bar-chart.ts
@@ -147,7 +147,7 @@ export class ObcRadialBarChart extends LitElement {
   /** Show debug overlay for development, default: false */
   @property({type: Boolean, reflect: true})
   showDebugOverlay = false;
-  /** Fixed height of the chart in pixels (mandatory, determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
+  /** Fixed height of the chart in pixels (determines chart circumference), default: 320. The chart's circumference is always based on this fixed height to match other radial instruments. */
   @property({type: Number, reflect: true})
   fixedHeight = 320;
   /** Minimum thickness of each ring in pixels, excluding borders, default: 16 */

--- a/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-line-base.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-line-base.ts
@@ -311,32 +311,15 @@ const LINE_GRAPH_RECREATE_PROP_NAMES = [
  * </script>
  * ```
  *
- * @property {Array<{label?: string, x?: number|string|Date|TemporalLike, value: number}>} data - Single-series data array. In `category` mode each item needs `label`; in `time`/`number` mode each item needs `x` (epoch ms, ISO string, Date, or Temporal object — `label` is parsed as a fallback). Used when `datasets` is not provided. Points are drawn in array order (no sorting); Temporal Plain* values are interpreted in the system time zone.
- * @property {ChartDataset<'line', (number | {x: number|string|Date|TemporalLike; y: number})[]>[]} datasets - Multi-series Chart.js datasets. Takes precedence over `data`. Each dataset can have `label`, `data` (numeric array or `{x, y}` points), and visual properties like `borderColor`, `backgroundColor`, `fill`, etc. In `time`/`number` mode point x-values are normalized like single-series `x`.
- * @property {(string|number)[]} labels - Explicit labels for category x-axis. If omitted, labels are derived from `data` property or dataset x-values.
- * @property {string[]} colors - Custom color palette (CSS variable names or color strings). Falls back to theme default colors if not provided.
- * @property {'category'|'time'|'number'} xAxisType - X-axis mode. `'category'` for labeled, evenly spaced data points; `'time'` for time-based data positioned proportionally (numbers are always epoch ms — `xStepSize`/`xTicksLimit` operate in ms); `'number'` for plain numeric x-values. Default: `'category'`.
- * @property {'minutes'|'date'} timeDisplay - Time axis label format when `xAxisType='time'`. `'date'` shows a locale date, `'minutes'` shows minutes relative to the latest data point. Default: `'date'`.
- * @property {'left'|'right'} yAxisPosition - Single y-axis position. Use this for simple charts with one y-axis. For multiple y-axes, use `yAxes` property instead. Default: `'left'`.
- * @property {Array<{id?: string; position?: 'left'|'right'; min?: number; max?: number; grid?: boolean}>} yAxes - Multiple y-axis definitions for complex charts. Each axis can specify `id` (referenced by dataset `yAxisID`), `position`, `min`/`max` range, and `grid` visibility.
- * @property {boolean} showGrid - Show vertical grid lines (x-axis). When combined with `showGridX` and `showGridY`, controls full grid visibility. Default: `false`.
- * @property {boolean} showGridX - Show vertical grid lines (x-axis). Set to `false` to hide only vertical lines while keeping horizontal lines. Default: `false`.
- * @property {boolean} showGridY - Show horizontal grid lines (y-axis). Set to `false` to hide only horizontal lines while keeping vertical lines. Default: `false`.
- * @property {boolean} showTickMarks - Show axis tick marks and labels. Automatically hidden below 192px height threshold. Default: `false`.
- * @property {boolean} showPoints - Show point markers on data points. Default: `false`.
- * @property {boolean} fill - Enable area fill under/between lines. Use with `fillMode` to control fill style. Default: `false`.
- * @property {'semitransparent'|'solid'|'threshold'} fillMode - Fill rendering mode. `'semitransparent'` uses 50% alpha, `'solid'` uses opaque fill, `'threshold'` (single-series only) fills above/below midpoint with red/blue gradient. Default: `'semitransparent'`.
- * @property {'smooth'|'straight'|'stepped'} lineMode - Line drawing style. `'smooth'` applies bezier curve tension, `'straight'` draws straight lines, `'stepped'` creates step-like lines. Default: `'smooth'`.
- * @property {boolean} stacked - Stack multi-series datasets vertically on y-axis. Ignored for single-series and threshold fill mode. Default: `false`.
- * @property {string} unit - Unit label displayed in tooltips (e.g., 'kW', 'kg', '%'). Default: empty string.
- * @property {number} xTicksLimit - Maximum number of x-axis ticks/grid lines. Useful for matching external axes. Optional.
- * @property {number} xStepSize - Force specific interval between x-axis ticks (e.g., 1, 2, 5). Useful for matching external axes. Optional.
- * @property {number} yTicksLimit - Maximum number of y-axis ticks/grid lines. Useful for matching external axes. Optional.
- * @property {number} yStepSize - Force specific interval between y-axis ticks (e.g., 2, 5, 10). Useful for matching external axes. Optional.
- * @property {boolean} legend - Show HTML legend below chart with series labels and colors. Default: `false`.
- * @property {number} height - Chart height in pixels. Determines chart size with 1.5:1 aspect ratio (width = height × 1.5). Default: `320`.
- * @property {boolean} showDebugOverlay - Development mode: show visual debug overlay with dimension guides. Shows blue border around canvas (axis area) and red border around chart grid (data area). Default: `false`.
+ * TODO(maintainer): `fill` is documented here as a class-level `@property` tag
+ * only because tooling (the manifest, lit-analyzer, story controls) still
+ * depends on it, yet no `@property`-decorated field backs it and no render path
+ * reads `this.fill` (fill is decided by the abstract `shouldApplyFill()`). Decide
+ * whether `fill` is a real public property (add a decorated field) or obsolete
+ * (remove this tag and the `.fill=` usages in the stories/wrappers). Kept as-is
+ * here to avoid changing the public API surface in a docs-only cleanup.
  *
+ * @property {boolean} fill - Enable area fill under/between lines. Use with `fillMode` to control fill style. Default: `false`.
  * @ignore This is an abstract base class. Use concrete implementations like ObcLineGraph or ObcAreaGraph instead.
  * @experimental
  */

--- a/packages/openbridge-webcomponents/src/integration-systems/integration-bar/integration-bar.ts
+++ b/packages/openbridge-webcomponents/src/integration-systems/integration-bar/integration-bar.ts
@@ -30,30 +30,6 @@ import {classMap} from 'lit/directives/class-map.js';
  * @slot clock - Custom clock content, rendered when `showClock` is true
  * @slot integration-buttons - Regular vessel integration buttons
  * @slot hug-buttons - Compact vessel integration buttons; slotted integration buttons are forced to hug type
- * @property {IntegrationBarType} type - Integration bar mode for fleet/vessel presentation
- * @property {boolean} hideHomeButton - Hides the home button when true
- * @property {boolean} showClock - Toggles rendering of the clock slot
- * @property {boolean} showLinkButton - Toggles visibility of link button
- * @property {boolean} linkButtonActivated - Activated state of link button
- * @property {boolean} showUserButton - Toggles visibility of user button
- * @property {boolean} userButtonActivated - Activated state of user button
- * @property {boolean} showDimmingButton - Toggles visibility of dimming button
- * @property {boolean} dimmingButtonActivated - Activated state of dimming button
- * @property {boolean} showSystemButton - Toggles visibility of system button
- * @property {boolean} systemButtonActivated - Activated state of system button
- * @property {boolean} showScreenButton - Toggles visibility of screen button
- * @property {boolean} screenButtonActivated - Activated state of screen button
- * @property {boolean} showNotificationButton - Toggles visibility of notification button
- * @property {boolean} notificationButtonActivated - Activated state of notification button
- * @property {boolean} showAlertButton - Toggles visibility of alert button
- * @property {boolean} alertButtonActivated - Activated state of alert button
- * @property {boolean} showFleetButton - Toggles visibility of fleet button
- * @property {boolean} fleetButtonSelected - Selected state of fleet button
- * @property {boolean} fleetButtonActivated - Active state of fleet button while selection is pending
- * @property {string} fleetButtonLabel - Label for the fleet button
- * @property {string} selectedVesselValue - Selected vessel value
- * @property {string} activeVesselValue - Active vessel value while selection is pending
- * @property {{value: string; label: string}[]} vesselSelectorOptions - Available vessel options
  * @fires fleet-button-click - Fired when the fleet button is clicked
  * @fires link-button-clicked - Fired when the link button is clicked
  * @fires alert-button-clicked - Fired when the alert button is clicked
@@ -66,25 +42,45 @@ import {classMap} from 'lit/directives/class-map.js';
  */
 @customElement('obc-integration-bar')
 export class ObcIntegrationBar extends LitElement {
+  /** Hides the home button when true */
   @property({type: Boolean}) hideHomeButton = false;
+  /** Toggles rendering of the clock slot */
   @property({type: Boolean}) showClock = false;
+  /** Toggles visibility of link button */
   @property({type: Boolean}) showLinkButton = false;
+  /** Activated state of link button */
   @property({type: Boolean}) linkButtonActivated = false;
+  /** Toggles visibility of user button */
   @property({type: Boolean}) showUserButton = false;
+  /** Activated state of user button */
   @property({type: Boolean}) userButtonActivated = false;
+  /** Toggles visibility of dimming button */
   @property({type: Boolean}) showDimmingButton = false;
+  /** Activated state of dimming button */
   @property({type: Boolean}) dimmingButtonActivated = false;
+  /** Toggles visibility of system button */
   @property({type: Boolean}) showSystemButton = false;
+  /** Activated state of system button */
   @property({type: Boolean}) systemButtonActivated = false;
+  /** Toggles visibility of screen button */
   @property({type: Boolean}) showScreenButton = false;
+  /** Activated state of screen button */
   @property({type: Boolean}) screenButtonActivated = false;
+  /** Toggles visibility of notification button */
   @property({type: Boolean}) showNotificationButton = false;
+  /** Activated state of notification button */
   @property({type: Boolean}) notificationButtonActivated = false;
+  /** Toggles visibility of alert button */
   @property({type: Boolean}) showAlertButton = false;
+  /** Activated state of alert button */
   @property({type: Boolean}) alertButtonActivated = false;
+  /** Toggles visibility of fleet button */
   @property({type: Boolean}) showFleetButton = false;
+  /** Selected state of fleet button */
   @property({type: Boolean}) fleetButtonSelected = false;
+  /** Active state of fleet button while selection is pending */
   @property({type: Boolean}) fleetButtonActivated = false;
+  /** Label for the fleet button */
   @property({type: String}) fleetButtonLabel = 'Fleet';
 
   @state() private buttonsOnBar = false;

--- a/packages/openbridge-webcomponents/src/integration-systems/integration-button/integration-button.ts
+++ b/packages/openbridge-webcomponents/src/integration-systems/integration-button/integration-button.ts
@@ -35,36 +35,38 @@ export enum IntegrationButtonType {
  *
  * @fires click - Fired when the internal button is activated.
  *
- * @property {boolean} hasTrailingIcon - Shows the `trailing-icon` slot.
- * @property {boolean} hasTrailingIcon2 - Shows the `trailing-icon2` slot.
- * @property {boolean} hasLeadingIcon - Shows the `leading-icon` slot.
- * @property {boolean} hasstatus - Shows the `status` slot.
- * @property {IntegrationButtonReadout[]} readouts - List of readout items shown in the rich type.
- * @property {boolean} disabled - Disables the internal button.
- * @property {boolean} activated - Applies active state styling while a selection is pending.
- * @property {boolean} selected - Applies selected state styling.
- * @property {boolean} dividerBottom - Shows a bottom divider under the button.
- * @property {boolean} dividerRight - Shows a right divider to separate from adjacent buttons.
- * @property {IntegrationButtonVariant} variant - Visual variant (`normal` or `flat`).
- * @property {IntegrationButtonType} type - Layout type (`hug`, `regular`, or `rich`).
  * @experimental
  */
 @customElement('obc-integration-button')
 export class ObcIntegrationButton extends LitElement {
+  /** Shows the `trailing-icon` slot. */
   @property({type: Boolean}) hasTrailingIcon = false;
-  /** @availableWhen hasTrailingIcon==true */
+  /**
+   * Shows the `trailing-icon2` slot.
+   * @availableWhen hasTrailingIcon==true
+   */
   @property({type: Boolean}) hasTrailingIcon2 = false;
+  /** Shows the `leading-icon` slot. */
   @property({type: Boolean}) hasLeadingIcon = false;
+  /** Shows the `status` slot. */
   @property({type: Boolean}) hasStatus = false;
+  /** List of readout items shown in the rich type. */
   @property({type: Array, attribute: false})
   readouts: IntegrationButtonReadout[] = [];
+  /** Disables the internal button. */
   @property({type: Boolean}) disabled = false;
+  /** Applies active state styling while a selection is pending. */
   @property({type: Boolean}) activated = false;
+  /** Applies selected state styling. */
   @property({type: Boolean}) selected = false;
+  /** Shows a bottom divider under the button. */
   @property({type: Boolean}) dividerBottom = false;
+  /** Shows a right divider to separate from adjacent buttons. */
   @property({type: Boolean}) dividerRight = false;
+  /** Visual variant (`normal` or `flat`). */
   @property({type: String}) variant: IntegrationButtonVariant =
     IntegrationButtonVariant.normal;
+  /** Layout type (`hug`, `regular`, or `rich`). */
   @property({type: String}) type: IntegrationButtonType =
     IntegrationButtonType.regular;
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass-flat/compass-flat.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass-flat/compass-flat.ts
@@ -58,14 +58,6 @@ export interface Label {
  * - **Color priority**: Per-element priority for HDG, COG, and ROT via
  *   `priorityElements`.
  *
- * @property {number} heading - Current heading in degrees.
- * @property {number} courseOverGround - Current COG in degrees.
- * @property {RotType|undefined} rotType - ROT display mode: `'dots'`, `'bar'`, or `undefined` (hidden).
- * @property {number|undefined} rateOfTurnDegreesPerMinute - Measured rate of turn in degrees per minute (positive = starboard). Drives the bar extent and (after `× rotDotAnimationFactor`) the dot animation.
- * @property {number} rotDotAnimationFactor - Visual amplification for the dot animation only. Default `18` (≈1 rpm at 20°/min).
- * @property {number} rotationsPerMinute - **Deprecated.** Use `rateOfTurnDegreesPerMinute` instead.
- * @property {number} rotMaxValue - Bar-extent reference value in **degrees per minute**. Default `60` per ES-TRIN 2025/1 Art. 3.02.
- * @property {number} rotArcExtent - Degrees of bar arc per max-value ROT (default 60).
  *
  * @ignition-base-height: 170px
  * @ignition-base-width: 512px
@@ -74,7 +66,9 @@ export interface Label {
 @customElement('obc-compass-flat')
 export class ObcCompassFlat extends LitElement {
   @property({type: Boolean}) FOVIndicator: boolean = false;
+  /** Current heading in degrees. */
   @property({type: Number}) heading = 0;
+  /** Current COG in degrees. */
   @property({type: Number}) courseOverGround = 0;
   @property({type: Number}) tickInterval = 5;
   @property({type: Number}) FOV = 45;
@@ -85,6 +79,7 @@ export class ObcCompassFlat extends LitElement {
   priorityElements: CompassFlatPriorityElement[] = [
     CompassFlatPriorityElement.hdg,
   ];
+  /** ROT display mode: `'dots'`, `'bar'`, or `undefined` (hidden). */
   @property({type: String}) rotType: RotType | undefined;
   /**
    * Measured rate of turn in degrees per minute (positive = starboard).
@@ -98,6 +93,7 @@ export class ObcCompassFlat extends LitElement {
    */
   @property({type: Number}) rotDotAnimationFactor: number = 18;
   /**
+   * **Deprecated.** Use `rateOfTurnDegreesPerMinute` instead.
    * @deprecated Use `rateOfTurnDegreesPerMinute` instead.
    * @availableWhen rotType!=undefined
    */
@@ -108,7 +104,10 @@ export class ObcCompassFlat extends LitElement {
    * @availableWhen rotType!=undefined
    */
   @property({type: Number}) rotMaxValue: number = 60;
-  /** @availableWhen rotType!=undefined */
+  /**
+   * Degrees of bar arc per max-value ROT (default 60).
+   * @availableWhen rotType!=undefined
+   */
   @property({type: Number}) rotArcExtent: number = 60;
   /** @availableWhen rotType!=undefined */
   @property({type: Boolean}) rotPortStarboard: boolean = false;

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.ts
@@ -59,9 +59,9 @@ export enum CompassPriorityElement {
  *   Supports spinning dots (`rotType="dots"`) — the dot animation is
  *   amplified by `rotDotAnimationFactor` so small physical values still
  *   read at a glance — and a banana-shaped arc bar (`rotType="bar"`)
- *   showing the HDG→COG span. Bar extent is driven by the physical value
- *   only (gain is not applied). Position on the outer scale ring or inner
- *   circle via `rotPosition`.
+ *   showing the rate of turn as an arc anchored at the current heading.
+ *   Bar extent is driven by the physical value only (gain is not applied).
+ *   Position on the outer scale ring or inner circle via `rotPosition`.
  * - **Environmental overlays**: Wind speed/direction and current
  *   speed/direction indicators on the watch face.
  * - **Vessel image**: Configurable vessel silhouette centered on the
@@ -176,13 +176,16 @@ export class ObcCompass extends LitElement {
    */
   @property({type: Number}) rotDotAnimationFactor: number = 18;
   /**
-   * Legacy spin speed of the ROT dot ring, in rotations per minute.
+   * Legacy rate-of-turn input, in rotations per minute. When
+   * `rateOfTurnDegreesPerMinute` is `undefined`, this value is used
+   * (unconverted) as the fallback ROT, driving both the spinning dot ring
+   * and the bar extent.
    * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally
    * `rotDotAnimationFactor`) instead. Takes effect only when
    * `rateOfTurnDegreesPerMinute` is `undefined`.
    */
   @property({type: Number}) rotationsPerMinute: number = 1;
-  /** ROT display mode: `'dots'` (spinning dots, default) or `'bar'` (arc bar from HDG to COG). */
+  /** ROT display mode: `'dots'` (spinning dots, default) or `'bar'` (a rate-of-turn arc anchored at the current heading, its length proportional to the rate of turn). */
   @property({type: String}) rotType: RotType = RotType.dots;
   /** ROT track position: `'innerCircle'` (default) or `'scale'` (on the outer ring). */
   @property({type: String}) rotPosition: RotPosition = RotPosition.innerCircle;

--- a/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/compass/compass.ts
@@ -94,25 +94,6 @@ export enum CompassPriorityElement {
  * ></obc-compass>
  * ```
  *
- * @property {number} heading - The current heading of the vessel in degrees.
- * @property {number} courseOverGround - The current course over ground in degrees.
- * @property {number | null} headingSetpoint - The set point for the heading in degrees.
- * @property {boolean} atHeadingSetpoint - Indicates if the vessel is at the heading set point.
- * @property {boolean} autoAtHeadingSetpoint - Enables automatic at heading set point calculation.
- * @property {number} autoAtHeadingSetpointDeadband - The deadband for the heading set point in degrees.
- * @property {boolean} touching - Indicates if the compass is being touched.
- * @property {Array<AngleAdvice>} headingAdvices - An array of angle advices for the compass.
- * @property {number | null} currentWindSpeedKnots - The wind speed in knots.
- * @property {number | null} windFromDirection - The direction the wind is coming from in degrees.
- * @property {number | null} currentSpeed - The current speed, number of arrows.
- * @property {number | null} currentFromDirection - The direction the current is coming from in degrees.
- * @property {VesselImage} vesselImage - The image of the vessel.
- * @property {number|undefined} rateOfTurnDegreesPerMinute - Measured rate of turn in degrees per minute (the AIS / ITU-R M.1371 convention). Sign controls direction (positive = starboard / clockwise). Drives both the bar extent and the dot animation.
- * @property {number} rotDotAnimationFactor - Visual amplification for the dot animation only. Default `18` (≈1 rpm at 20°/min).
- * @property {number} rotationsPerMinute - **Deprecated.** Use `rateOfTurnDegreesPerMinute` instead. Kept as a backward-compatible fallback when `rateOfTurnDegreesPerMinute` is `undefined`.
- * @property {RotType} rotType - ROT display mode: `'dots'` (spinning dots, default) or `'bar'` (arc bar from HDG to COG).
- * @property {RotPosition} rotPosition - ROT track position: `'innerCircle'` (default) or `'scale'` (on the outer ring).
- * @property {Priority} priority - Color priority: `Priority.enhanced` uses the blue/enhanced color palette, `Priority.regular` (default) uses the standard palette.
  *
  * @ignition-base-height: 512px
  * @ignition-base-width: 512px
@@ -120,36 +101,65 @@ export enum CompassPriorityElement {
  */
 @customElement('obc-compass')
 export class ObcCompass extends LitElement {
+  /** The current heading of the vessel in degrees. */
   @property({type: Number}) heading = 0;
+  /** The current course over ground in degrees. */
   @property({type: Number}) courseOverGround = 0;
 
+  /** The set point for the heading in degrees. */
   @property({type: Number}) headingSetpoint: number | null = null;
   /** @availableWhen headingSetpoint!=null */
   @property({type: Number}) newHeadingSetpoint: number | undefined;
-  /** @availableWhen headingSetpoint!=null && autoAtHeadingSetpoint==false */
+  /**
+   * Indicates if the vessel is at the heading set point.
+   * @availableWhen headingSetpoint!=null && autoAtHeadingSetpoint==false
+   */
   @property({type: Boolean}) atHeadingSetpoint: boolean = false;
   /** @availableWhen headingSetpoint!=null */
   @property({type: Number}) headingSetpointAtZeroDeadband: number = 0.5;
   /** @availableWhen headingSetpoint!=null */
   @property({type: Boolean}) headingSetpointOverride: boolean = false;
-  /** @availableWhen headingSetpoint!=null */
+  /**
+   * Enables automatic at heading set point calculation.
+   * @availableWhen headingSetpoint!=null
+   */
   @property({type: Boolean, attribute: false}) autoAtHeadingSetpoint: boolean =
     true;
-  /** @availableWhen headingSetpoint!=null && autoAtHeadingSetpoint==true */
+  /**
+   * The deadband for the heading set point in degrees.
+   * @availableWhen headingSetpoint!=null && autoAtHeadingSetpoint==true
+   */
   @property({type: Number}) autoAtHeadingSetpointDeadband: number = 2;
   /** @availableWhen headingSetpoint!=null */
   @property({type: Boolean}) animateSetpoint: boolean = false;
-  /** @availableWhen headingSetpoint!=null */
+  /**
+   * Indicates if the compass is being touched.
+   * @availableWhen headingSetpoint!=null
+   */
   @property({type: Boolean}) touching: boolean = false;
+  /** An array of angle advices for the compass. */
   @property({type: Array, attribute: false}) headingAdvices: AngleAdvice[] = [];
-  /** @availableWhen windFromDirection!=null */
+  /**
+   * The wind speed in knots.
+   * @availableWhen windFromDirection!=null
+   */
   @property({type: Number}) currentWindSpeedKnots: number | null = null;
-  /** @availableWhen currentWindSpeedKnots!=null */
+  /**
+   * The direction the wind is coming from in degrees.
+   * @availableWhen currentWindSpeedKnots!=null
+   */
   @property({type: Number}) windFromDirection: number | null = null;
-  /** @availableWhen currentFromDirection!=null */
+  /**
+   * The current speed, number of arrows.
+   * @availableWhen currentFromDirection!=null
+   */
   @property({type: Number}) currentSpeed: number | null = null;
-  /** @availableWhen currentSpeed!=null */
+  /**
+   * The direction the current is coming from in degrees.
+   * @availableWhen currentSpeed!=null
+   */
   @property({type: Number}) currentFromDirection: number | null = null;
+  /** The image of the vessel. */
   @property({type: String}) vesselImage: VesselImage = VesselImage.genericTop;
   /**
    * Measured rate of turn in degrees per minute (positive = starboard).
@@ -166,12 +176,15 @@ export class ObcCompass extends LitElement {
    */
   @property({type: Number}) rotDotAnimationFactor: number = 18;
   /**
+   * Legacy spin speed of the ROT dot ring, in rotations per minute.
    * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally
    * `rotDotAnimationFactor`) instead. Takes effect only when
    * `rateOfTurnDegreesPerMinute` is `undefined`.
    */
   @property({type: Number}) rotationsPerMinute: number = 1;
+  /** ROT display mode: `'dots'` (spinning dots, default) or `'bar'` (arc bar from HDG to COG). */
   @property({type: String}) rotType: RotType = RotType.dots;
+  /** ROT track position: `'innerCircle'` (default) or `'scale'` (on the outer ring). */
   @property({type: String}) rotPosition: RotPosition = RotPosition.innerCircle;
   /**
    * Bar-extent reference value in **degrees per minute**. The bar fills the
@@ -192,6 +205,7 @@ export class ObcCompass extends LitElement {
   @property({type: String}) direction: CompassDirection =
     CompassDirection.NorthUp;
   @property({type: String}) state: InstrumentState = InstrumentState.active;
+  /** Color priority: `Priority.enhanced` uses the blue/enhanced color palette, `Priority.regular` (default) uses the standard palette. */
   @property({type: String}) priority: Priority = Priority.regular;
   /** @availableWhen priority==enhanced */
   @property({type: Array, attribute: false})

--- a/packages/openbridge-webcomponents/src/navigation-instruments/gauge-trend/gauge-trend.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/gauge-trend/gauge-trend.ts
@@ -115,11 +115,6 @@ export {FillMode, ScaleType};
  * ></obc-gauge-trend>
  * ```
  *
- * @property {number} width - Chart width in pixels (defines aspect ratio)
- * @property {number} height - Chart height in pixels (defines aspect ratio)
- * @property {boolean} enhanced - Use enhanced color palette for chart and scales
- * @property {InstrumentState} state - Instrument state (automatically applied to scale)
- * @property {boolean} chartFill - Enable chart area fill (default: false for line-only)
  *
  * Setpoint properties are inherited from {@link SetpointMixin}.
  * These are forwarded to the internal `obc-bar-vertical` scale:

--- a/packages/openbridge-webcomponents/src/navigation-instruments/graph-mini/graph-mini.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/graph-mini/graph-mini.ts
@@ -8,11 +8,11 @@ import {customElement} from '../../decorator.js';
  * @element obc-graph-mini
  * @description A mini graph component
  *
- * @property {Array} data - The data to display in the graph, first array is the x values, second array is the y values
  * @beta
  */
 @customElement('obc-graph-mini')
 export class ObcGraphMini extends LitElement {
+  /** The data to display in the graph, first array is the x values, second array is the y values */
   @property({type: Array})
   data: [number[], number[]] = [[], []];
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/indicator-graph/indicator-graph.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/indicator-graph/indicator-graph.ts
@@ -26,11 +26,11 @@ export interface ObcIndicatorGraphLayout {
  * @element obc-indicator-graph
  * @description A mini graph component
  *
- * @property {Array} data - The data to display in the graph, first array is the x values, second array is the y values
  * @beta
  */
 @customElement('obc-indicator-graph')
 export class ObcIndicatorGraph extends LitElement {
+  /** The data to display in the graph, first array is the x values, second array is the y values */
   @property({type: Array})
   data: [number[], number[]] = [[], []];
 

--- a/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/watch/watch.ts
@@ -161,22 +161,6 @@ const RADIAL_SETPOINT_INWARD_ADJUST = 4;
  * `_setpointCssAngle` tracks the accumulated CSS angle to avoid long-way-around
  * transitions across the 0°/360° boundary.
  *
- * @property {InstrumentState} state - Instrument state (active, loading, off)
- * @property {Priority} priority - Color priority (enhanced = blue palette, regular = gray palette)
- * @property {number|undefined} angleSetpoint - Setpoint angle in degrees (0° = 12 o'clock)
- * @property {number|undefined} newAngleSetpoint - New setpoint being adjusted (focus mode)
- * @property {boolean} atAngleSetpoint - Whether value matches setpoint (within deadband)
- * @property {number} angleSetpointAtZeroDeadband - Deadband for zero detection (default 0.5°)
- * @property {boolean} setpointOverride - Override to derive setpoint color from priority regardless of state
- * @property {RotType|undefined} rotType - ROT visualization type: `'dots'` (spinning dots) or `'bar'` (arc bar with clipped dots). Undefined hides the ROT layer.
- * @property {RotPosition} rotPosition - Track on which ROT elements are placed: `'scale'` (on the outer ring) or `'innerCircle'` (default, inside the inner ring)
- * @property {number} rotStartAngle - Start angle of the ROT bar arc in degrees (0° = 12 o'clock, clockwise). Only used when `rotType` is `'bar'`.
- * @property {number} rotEndAngle - End angle of the ROT bar arc in degrees. The bar is hidden when the difference from `rotStartAngle` is less than 0.1°.
- * @property {Priority|undefined} rotPriority - Override priority for ROT color derivation. When set, ROT colors use this instead of the main `priority`. Useful when the ROT element has independent priority (e.g. compass per-element priority).
- * @property {number|undefined} rateOfTurnDegreesPerMinute - Measured rate of turn in degrees per minute (the maritime/AIS convention, see ES-TRIN 2025/1 Art. 3.02 and ITU-R M.1371). Sign controls direction (positive = starboard/clockwise). When defined, this drives both the dot animation (multiplied by `rotDotAnimationFactor`) and the port/starboard direction sign.
- * @property {number} rotDotAnimationFactor - Visual amplification factor applied only to the spinning-dot animation (not to bar extent). Default `18` keeps the legacy visual feel (≈1 rpm at 20°/min).
- * @property {number} rotationsPerMinute - **Deprecated.** Spin speed of the ROT dot ring in rotations per minute. Sign controls direction (positive = clockwise). Use `rateOfTurnDegreesPerMinute` instead.
- * @property {ZoomToFitArcFrame|undefined} arcFrame - Pre-computed zoom-to-fit arc frame. When set, the watch skips its own `computeZoomToFitArcFrame()` call and uses these values directly. Consumer instruments (e.g. rudder, instrument-radial) should compute the frame once and pass it here to avoid redundant computation. If you pass `arcFrame`, you own keeping it in sync with `areas` / `watchCircleType` — obc-watch will NOT recompute it, so a stale frame renders stale geometry.
  * @experimental
  */
 @customElement('obc-watch')
@@ -184,16 +168,23 @@ export class ObcWatch extends LitElement {
   private _setpointId = `watch-setpoint-${Math.random().toString(36).slice(2, 9)}`;
   private _newSetpointId = `watch-new-setpoint-${Math.random().toString(36).slice(2, 9)}`;
 
+  /** Instrument state (active, loading, off) */
   @property({type: String}) state: InstrumentState = InstrumentState.active;
+  /** Color priority (enhanced = blue palette, regular = gray palette) */
   @property({type: String}) priority: Priority = Priority.regular;
   @property({type: String}) watchCircleType: WatchCircleType =
     WatchCircleType.single;
   @property({type: Boolean}) northArrow: boolean = false;
   @property({type: Boolean}) northArrowInside: boolean | undefined;
+  /** Setpoint angle in degrees (0° = 12 o'clock) */
   @property({type: Number}) angleSetpoint: number | undefined;
+  /** New setpoint being adjusted (focus mode) */
   @property({type: Number}) newAngleSetpoint: number | undefined;
+  /** Whether value matches setpoint (within deadband) */
   @property({type: Boolean}) atAngleSetpoint: boolean = false;
+  /** Deadband for zero detection (default 0.5°) */
   @property({type: Number}) angleSetpointAtZeroDeadband: number = 0.5;
+  /** Override to derive setpoint color from priority regardless of state */
   @property({type: Boolean}) setpointOverride: boolean = false;
   @property({type: Boolean}) touching: boolean = false;
 
@@ -250,17 +241,25 @@ export class ObcWatch extends LitElement {
   @property({type: Number}) scaleWindIcon: number = 1;
   @property({type: Number}) rotation: number | undefined;
   @property({type: Boolean}) zoomToFitArc: boolean = false;
+  /** Pre-computed zoom-to-fit arc frame. When set, the watch skips its own `computeZoomToFitArcFrame()` call and uses these values directly. Consumer instruments (e.g. rudder, instrument-radial) should compute the frame once and pass it here to avoid redundant computation. If you pass `arcFrame`, you own keeping it in sync with `areas` / `watchCircleType` — obc-watch will NOT recompute it, so a stale frame renders stale geometry. */
   @property({attribute: false}) arcFrame: ZoomToFitArcFrame | undefined;
   @property({type: Number}) tickFadeAngle: number = 0;
 
+  /** ROT visualization type: `'dots'` (spinning dots) or `'bar'` (arc bar with clipped dots). Undefined hides the ROT layer. */
   @property({type: String}) rotType: RotType | undefined;
+  /** Track on which ROT elements are placed: `'scale'` (on the outer ring) or `'innerCircle'` (default, inside the inner ring) */
   @property({type: String}) rotPosition: RotPosition = RotPosition.innerCircle;
+  /** Start angle of the ROT bar arc in degrees (0° = 12 o'clock, clockwise). Only used when `rotType` is `'bar'`. */
   @property({type: Number}) rotStartAngle: number = 0;
+  /** End angle of the ROT bar arc in degrees. The bar is hidden when the difference from `rotStartAngle` is less than 0.1°. */
   @property({type: Number}) rotEndAngle: number = 0;
+  /** Override priority for ROT color derivation. When set, ROT colors use this instead of the main `priority`. Useful when the ROT element has independent priority (e.g. compass per-element priority). */
   @property({type: String}) rotPriority: Priority | undefined;
   @property({type: Boolean}) rotPortStarboard: boolean = false;
   @property({type: Number}) rotAtZeroDeadband: number = ROT_ZERO_DEADBAND_DEG;
+  /** Measured rate of turn in degrees per minute (the maritime/AIS convention, see ES-TRIN 2025/1 Art. 3.02 and ITU-R M.1371). Sign controls direction (positive = starboard/clockwise). When defined, this drives both the dot animation (multiplied by `rotDotAnimationFactor`) and the port/starboard direction sign. */
   @property({type: Number}) rateOfTurnDegreesPerMinute: number | undefined;
+  /** Visual amplification factor applied only to the spinning-dot animation (not to bar extent). Default `18` keeps the legacy visual feel (≈1 rpm at 20°/min). */
   @property({type: Number}) rotDotAnimationFactor: number = 18;
   /**
    * @deprecated Use `rateOfTurnDegreesPerMinute` (and optionally `rotDotAnimationFactor`) instead.
@@ -271,6 +270,7 @@ export class ObcWatch extends LitElement {
   set rotationsPerMinute(value: number) {
     this._legacyRotationsPerMinute = value;
   }
+  /** Legacy spin speed of the ROT dot ring, in rotations per minute (sign controls direction; positive = clockwise). */
   get rotationsPerMinute() {
     return this._legacyRotationsPerMinute;
   }


### PR DESCRIPTION
Closes #1043. Follow-up to #1042.

## Problem

Per AGENTS.md §3.6, properties must be documented **inline** above their field declarations. But 13 files used class-level `@property` JSDoc tags in the class-description block. `cem analyze` reads these and they:
- **override** the real inline docs (often with staler/terser text), and
- inject **ghost members** for properties that don't exist — the same manifest-accuracy bug class as #1033's ghost `hasTitleContainer`.

## Approach (careful, not brute-force)

Investigated empirically first (see #1043 discussion). Migrated ~130 tags across the chart, compass/instrument, and integration families + abstract `ObcChartLineBase` to inline JSDoc, then removed the class-level tags. Every change was gated by a **full before/after manifest diff** (`npm run analyze`).

### Ghost members eliminated (10)
Documented but non-existent properties, now gone from the manifest:
- `gauge-trend` **`enhanced`** — real API is `priority=Priority.enhanced`
- `polar-chart` **`trimToDiscreteStops`** — 0 code occurrences
- `integration-bar` **`type` / `selectedVesselValue` / `activeVesselValue` / `vesselSelectorOptions`** — 0 code occurrences
- `integration-button` **`hasstatus`** — typo for the real `hasStatus` (description migrated to it)
- `line-graph` / `gauge-trend` **`fillMode` / `stacked`** — real only on `area-graph` (which declares them with inline `@property`); phantom on the others

### Real descriptions preserved
The manifest diff confirmed **0 descriptions lost**. Three edge cases the migrator initially missed were fixed by hand: `pie-chart.data` (deeply-nested-brace tag type), `compass.rotationsPerMinute` (wrapped `@deprecated` block), `watch.rotationsPerMinute` (getter/setter accessor). Existing `@availableWhen` annotations preserved (**41 → 41**).

### Kept as documented exceptions
- **`ObcChartLineBase.fill`** — no `@property`-decorated field backs it and no render path reads `this.fill` (fill is decided by the abstract `shouldApplyFill()`), yet the manifest, **lit-analyzer**, and story controls still depend on the tag (`.fill=${true}` is used in the base stories). Restored with a `TODO(maintainer)` to decide separately whether `fill` is a real property (add a decorated field) or obsolete (remove tag + story usage). Avoids changing the public API surface in a docs-only change.
- **`setpoint-mixin` / `setpoint-bundle`** — a mixin legitimately documents the properties it injects into consumers (AGENTS.md §3).

## Prevention
`npm run lint:slots` now also flags class-level `@property` tags (allowlisting the exceptions above). `@attr`/`@attribute` for a CSS-only attribute with no backing field (e.g. slider `hugcontainer`) is intentionally allowed — there is no field to annotate.

## Verification
- **Manifest diff** (before/after `npm run analyze`): 10 ghost members removed, every real property description preserved (kept / migrated / fell back to canonical inline), 0 members added.
- `npm run lint` — **lit-analyzer: 0 problems in 2719 files**
- `npm run typecheck` ✅ · `npm run lint:slots` ✅ · prettier ✅
- No story files or property *declarations* changed — only JSDoc, so Storybook argTypes/controls for real properties are unaffected; only dead ghost controls disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation rules to forbid class-block `@property` tags to prevent “ghost” member issues, while still allowing `@attr`/`@attribute` for CSS-only attributes without backing fields.
  * Reworked component input docs across multiple web components to use concise inline per-property comments instead of large class-level `@property` blocks, refreshing availability, defaults, and deprecation guidance.
  * Updated the `fill` input note to clarify it isn’t backed by a decorated field.
* **Chores**
  * Strengthened CI auditing to detect disallowed class-block property annotations and fail the build when found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->