### PR TITLE
feat(instruments): add draft-trim instrument

### DIFF
--- a/packages/openbridge-webcomponents/src/navigation-instruments/draft-trim/draft-trim.stories.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/draft-trim/draft-trim.stories.ts
@@ -1,0 +1,59 @@
+import type {Meta, StoryObj} from '@storybook/web-components-vite';
+import {ObcDraftTrim} from './draft-trim.js';
+import './draft-trim.js';
+import {widthDecorator} from '../../storybook-util.js';
+import {Priority} from '../types.js';
+import {VesselImage} from '../watch/vessel.js';
+import {sideVessels} from '../watch/vessels/storybook-helper.js';
+
+const meta: Meta<typeof ObcDraftTrim> = {
+  title: 'Instruments/Draft Trim',
+  tags: ['autodocs', 'wip', 'skip-test'],
+  component: 'obc-draft-trim',
+  args: {
+    width: 400,
+    draftAft: 5,
+    draftFore: 2.5,
+    trim: -0.5,
+    instrumentRange: 10,
+    primaryTickmarkInterval: 5,
+    secondaryTickmarkInterval: 1,
+    vesselImage: VesselImage.psvSide,
+    vesselScale: 1,
+    priority: Priority.regular,
+  },
+  argTypes: {
+    width: {control: {type: 'range', min: 100, max: 1000, step: 1}},
+    draftAft: {control: {type: 'range', min: 0, max: 10, step: 0.1}},
+    draftFore: {control: {type: 'range', min: 0, max: 10, step: 0.1}},
+    trim: {control: {type: 'range', min: -10, max: 10, step: 0.1}},
+    instrumentRange: {control: {type: 'range', min: 1, max: 30, step: 1}},
+    primaryTickmarkInterval: {control: {type: 'number'}},
+    secondaryTickmarkInterval: {control: {type: 'number'}},
+    vesselImage: {control: 'select', options: sideVessels},
+    vesselScale: {control: {type: 'range', min: 0.5, max: 2, step: 0.05}},
+    priority: {control: 'select', options: Object.values(Priority)},
+  },
+  decorators: [widthDecorator],
+} satisfies Meta<ObcDraftTrim>;
+
+export default meta;
+type Story = StoryObj<ObcDraftTrim>;
+
+export const Regular: Story = {
+  args: {},
+};
+
+export const Enhanced: Story = {
+  args: {
+    priority: Priority.enhanced,
+  },
+};
+
+export const EvenKeel: Story = {
+  args: {
+    draftAft: 4,
+    draftFore: 4,
+    trim: 0,
+  },
+};

--- a/packages/openbridge-webcomponents/src/navigation-instruments/draft-trim/draft-trim.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/draft-trim/draft-trim.ts
@@ -51,14 +51,20 @@ export class ObcDraftTrim extends LitElement {
   @property({type: Number}) vesselScale = 1;
   @property({type: String}) priority: Priority = Priority.regular;
 
+  private get safeInstrumentRange(): number {
+    return Number.isFinite(this.instrumentRange) && this.instrumentRange > 0
+      ? this.instrumentRange
+      : 10;
+  }
+
   private renderGauge(draft: number) {
     return watchfaceLinear(
       {
         height: GAUGE_HEIGHT,
         width: GAUGE_WIDTH,
         scaleWidth: SCALE_WIDTH,
-        minValue: -this.instrumentRange,
-        maxValue: this.instrumentRange,
+        minValue: -this.safeInstrumentRange,
+        maxValue: this.safeInstrumentRange,
       },
       [{min: -draft, max: 0}],
       {value: -draft},

--- a/packages/openbridge-webcomponents/src/navigation-instruments/draft-trim/draft-trim.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/draft-trim/draft-trim.ts
@@ -1,0 +1,157 @@
+import {LitElement, html, css, nothing} from 'lit';
+import {property} from 'lit/decorators.js';
+import {customElement} from '../../decorator.js';
+import {watchfaceLinear} from '../../building-blocks/instrument-linear/instrument-linear.js';
+import {VesselImage} from '../watch/watch.js';
+import {vesselImages} from '../watch/vessel.js';
+import {Priority} from '../types.js';
+
+const GAUGE_WIDTH = 120;
+const GAUGE_HEIGHT = 384;
+const SCALE_WIDTH = 48;
+const GAUGE_CENTER_X = 132;
+const PANEL_HALF_WIDTH = 96;
+const PANEL_HALF_HEIGHT = 168;
+const WATER_INSET = 2;
+const VESSEL_BASE_SCALE = 1.11;
+
+/**
+ * Draft-trim instrument
+ *
+ * Displays the vessel's draft at the aft and fore ends as two vertical linear
+ * gauges, together with a side-profile vessel image tilted by the trim angle.
+ * Each gauge fills from the waterline down to the measured draft and marks the
+ * value with a rounded bar.
+ *
+ * ## Features / Variants
+ * - Aft draft gauge on the left (scale facing outward) and fore draft gauge on
+ *   the right, both spanning `-instrumentRange` to `instrumentRange` with the
+ *   waterline at the center.
+ * - Regular and enhanced color variants via the `priority` property.
+ * - Configurable vessel image (side-profile), vessel scale, and tick mark
+ *   intervals.
+ *
+ * ## Usage Guidelines
+ * Use this component to show fore/aft draft readings and the resulting trim
+ * attitude. For vertical motion around a mean level, use `obc-heave`; for
+ * distance to the seabed, use `obc-depth-actual`.
+ */
+@customElement('obc-draft-trim')
+export class ObcDraftTrim extends LitElement {
+  @property({type: Number}) draftAft = 0;
+  @property({type: Number}) draftFore = 0;
+  /** Trim angle in degrees; positive values tilt the bow down. */
+  @property({type: Number}) trim = 0;
+  /** Draft value at the bottom of each gauge; the waterline is at zero. */
+  @property({type: Number}) instrumentRange = 10;
+  @property({type: Number}) primaryTickmarkInterval = 5;
+  @property({type: Number}) secondaryTickmarkInterval = 1;
+  @property({type: String}) vesselImage: VesselImage = VesselImage.psvSide;
+  /** @availableWhen vesselImage!='' */
+  @property({type: Number}) vesselScale = 1;
+  @property({type: String}) priority: Priority = Priority.regular;
+
+  private renderGauge(draft: number) {
+    return watchfaceLinear(
+      {
+        height: GAUGE_HEIGHT,
+        width: GAUGE_WIDTH,
+        scaleWidth: SCALE_WIDTH,
+        minValue: -this.instrumentRange,
+        maxValue: this.instrumentRange,
+      },
+      [{min: -draft, max: 0}],
+      {value: -draft},
+      {container: 'var(--instrument-frame-primary-color)'},
+      {hideContainer: false, off: false, priority: this.priority},
+      {
+        mainTickmarks: [0],
+        primaryTickmarkInterval: this.primaryTickmarkInterval,
+        secondaryTickmarkInterval: this.secondaryTickmarkInterval,
+      },
+      []
+    );
+  }
+
+  override render() {
+    const vesselScale = VESSEL_BASE_SCALE * this.vesselScale;
+
+    return html`
+      <div class="container">
+        <svg viewBox="-192 -192 384 384">
+          <rect
+            x=${-PANEL_HALF_WIDTH + WATER_INSET}
+            y="0"
+            width=${(PANEL_HALF_WIDTH - WATER_INSET) * 2}
+            height=${PANEL_HALF_HEIGHT}
+            fill="var(--instrument-frame-secondary-color)"
+          />
+          <line
+            x1=${-PANEL_HALF_WIDTH}
+            x2=${PANEL_HALF_WIDTH}
+            y1=${-PANEL_HALF_HEIGHT}
+            y2=${-PANEL_HALF_HEIGHT}
+            stroke="var(--instrument-frame-tertiary-color)"
+            stroke-width="1"
+            vector-effect="non-scaling-stroke"
+          />
+          <line
+            x1=${-PANEL_HALF_WIDTH}
+            x2=${PANEL_HALF_WIDTH}
+            y1=${PANEL_HALF_HEIGHT}
+            y2=${PANEL_HALF_HEIGHT}
+            stroke="var(--instrument-frame-tertiary-color)"
+            stroke-width="1"
+            vector-effect="non-scaling-stroke"
+          />
+          <line
+            x1=${-PANEL_HALF_WIDTH}
+            x2=${PANEL_HALF_WIDTH}
+            y1="0"
+            y2="0"
+            stroke="var(--instrument-frame-tertiary-color)"
+            stroke-width="1"
+            vector-effect="non-scaling-stroke"
+          />
+          <g
+            style="transform: rotate(${this.trim}deg) scale(${vesselScale}) translate(-80px, -80px);"
+          >
+            ${this.vesselImage ? vesselImages[this.vesselImage] : nothing}
+          </g>
+          <g transform="translate(${GAUGE_CENTER_X}, 0)">
+            ${this.renderGauge(this.draftFore)}
+          </g>
+          <g transform="translate(${-GAUGE_CENTER_X}, 0) scale(-1, 1)">
+            ${this.renderGauge(this.draftAft)}
+          </g>
+        </svg>
+      </div>
+    `;
+  }
+
+  static override styles = css`
+    * {
+      box-sizing: border-box;
+    }
+
+    .container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+
+    .container > * {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'obc-draft-trim': ObcDraftTrim;
+  }
+}

--- a/packages/openbridge-webcomponents/src/navigation-instruments/draft-trim/draft-trim.ts
+++ b/packages/openbridge-webcomponents/src/navigation-instruments/draft-trim/draft-trim.ts
@@ -114,7 +114,8 @@ export class ObcDraftTrim extends LitElement {
             vector-effect="non-scaling-stroke"
           />
           <g
-            style="transform: rotate(${this.trim}deg) scale(${vesselScale}) translate(-80px, -80px);"
+            style="transform: rotate(${this
+              .trim}deg) scale(${vesselScale}) translate(-80px, -80px);"
           >
             ${this.vesselImage ? vesselImages[this.vesselImage] : nothing}
           </g>


### PR DESCRIPTION
## What

New `obc-draft-trim` navigation instrument implementing the OpenBridge 6.1 **Draft-trim** Figma design (node 20122-231157), Priority=False / Enhanced variants.

- **Two vertical draft gauges** — aft (left, mirrored so the scale faces outward) and fore (right) — built on the `watchfaceLinear` building block, same as `obc-heave` / `obc-depth-actual` / #1064. Fill runs from the waterline down to the draft value with a rounded bar marker.
- **Center panel** with waterline, top/bottom frame lines, water fill, and a side-profile vessel image (`vesselImages`, default `psvSide`) rotated by a `trim` property (degrees, positive = bow down — same sign convention as `pitch` in `obc-pitch-roll`).
- **Priority variants**: `priority: Priority` swaps regular/enhanced semantic instrument tokens (handled inside `watchfaceLinear`); all colors are semantic CSS variables, no hex.
- API: `draftAft`, `draftFore`, `trim`, `instrumentRange`, `primaryTickmarkInterval`, `secondaryTickmarkInterval`, `vesselImage`, `vesselScale`, `priority`.
- Stories (Regular / Enhanced / EvenKeel) tagged `['autodocs', 'wip', 'skip-test']` — no visual baselines yet while in development.

## Design decisions (for review)

- `trim` is an explicit property rather than derived from the draft difference (physical trim angle would require vessel length).
- The vessel stays fixed on the waterline; mean draft does not sink the image (static in the design).
- No `minAvg*/maxAvg*` trend bands — the design shows none; the gauge box slot is used for the waterline→draft fill itself.

## Validation

- `npx tsc --noEmit` clean
- `eslint src/navigation-instruments/draft-trim --max-warnings 0` clean
- `npm run analyze` — `obc-draft-trim` present in the manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `obc-draft-trim` navigation instrument web component that renders fore and aft draft gauges, a trim angle visualization, and configurable tick/scale settings.
  * Included adjustable vessel side-profile rendering, with image selection and dynamic positioning driven by the trim value and vessel scaling.
  * Added new Storybook stories showcasing Regular, Enhanced priority, and EvenKeel (zero-trim) configurations for the instrument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->