### PR TITLE
fix(charts): fill the container at any aspect ratio and zoom level

### DIFF
--- a/.cursor/rules/line-area-charts.mdc
+++ b/.cursor/rules/line-area-charts.mdc
@@ -231,8 +231,13 @@ fills its container's width and derives its height as
 is never consulted**. So a consumer that wants the chart to fill a box must
 feed that box's measured size back as `width` / `height` — this is what
 `obc-automation-tank` does with a `ResizeObserver` on its chart cell. Leaving
-the 384×384 default in a 900×200 box renders a 900×600 chart that overflows;
-that is the contract working, not a bug.
+the inherited 480×320 default (1.5:1) in a 900×200 box renders a 900×600 chart
+that overflows; that is the contract working, not a bug.
+
+Do not confuse that ratio with `scaleReferenceSize` (default 384). The ratio
+decides the component's own box; `scaleReferenceSize` is the size at which a
+slotted external scale draws 1:1 with the Figma design, and only scales the
+decorations inside it. They are unrelated numbers that both look like sizes.
 
 **The three CSS invariants**, all in `charthelpers/chart-common.css` and all
 scoped to `:host([fixedaspectratioscaling])`:

--- a/.cursor/rules/line-area-charts.mdc
+++ b/.cursor/rules/line-area-charts.mdc
@@ -219,6 +219,64 @@ Chart padding has **multiple independent code paths** that must stay in sync. Wh
 - Advice/setpoint overlays drawn by slotted bars live **outside** the bar band. If you collapse the scale/label band, the bar must reserve a separate advice/setpoint allowance (see `computeAdviceBandThickness` in `external-scale.ts`) — otherwise overlays clip at the SVG edge AND the chart canvas overlaps them because `reportDimensions` returned a thickness too small.
 - Positive-default boolean properties (e.g. `hasLabelPadding = true`, see AGENTS.md § 2) must be declared with `attribute: false`. Pure JS property; framework wrappers handle it transparently.
 
+### Fixed-Aspect Sizing — Invariants That Look Removable But Are Not
+
+`fixedAspectRatioScaling` mode has a specific contract and three CSS
+declarations that each look like tidy-up candidates. Removing any one of them
+silently reintroduces a shipped bug (issue #1138).
+
+**The contract.** `width` / `height` are a **ratio**, not pixels. The component
+fills its container's width and derives its height as
+`measuredWrapperWidth / (width / height)`. The container's available **height
+is never consulted**. So a consumer that wants the chart to fill a box must
+feed that box's measured size back as `width` / `height` — this is what
+`obc-automation-tank` does with a `ResizeObserver` on its chart cell. Leaving
+the 384×384 default in a 900×200 box renders a 900×600 chart that overflows;
+that is the contract working, not a bug.
+
+**The three CSS invariants**, all in `charthelpers/chart-common.css` and all
+scoped to `:host([fixedaspectratioscaling])`:
+
+1. `.canvas-and-slots-container { width: 100% }` — the container must stay a
+   **definite box**. `.wrapper` is a column flex with `align-items: center`, so
+   without this the container is shrink-to-fit; `canvas { width: 100% }` then
+   degrades to `auto`, and a canvas with an auto width and a definite height
+   resolves against its **intrinsic 2:1 ratio** (the 300×150 default). The
+   chart silently caps at `height * 2` and anything wider gets side gutters.
+2. `canvas { margin: 0 }` — Chart.js `getMaximumSize()` **subtracts the
+   canvas' resolved margins** from the container width. `margin: 0 auto`
+   centres the canvas and then donates the leftover space to the margins
+   permanently, so the canvas can never grow into it. Not even an explicit
+   `chart.resize()` recovers.
+3. `canvas { width: 100% !important; height: var(--chart-height) !important }`
+   — the `!important` is load-bearing. Chart.js writes its own measurement back
+   as an inline `style`, and see the measurement rule below for why that number
+   is wrong under `zoom`. Overriding it pins the canvas to the box layout
+   actually gave it; Chart.js keeps its measurement for the drawing buffer,
+   which converges to the same CSS-pixel size (no resolution loss).
+
+**Measurement under CSS `zoom`.** `getBoundingClientRect()` is zoom-scaled;
+`clientWidth` / `clientHeight` and `ResizeObserver` `contentRect` are **not**.
+So never turn a `getBoundingClientRect()` result back into a CSS-pixel style —
+the browser applies the zoom a second time and the element lands at `zoom²` of
+its box. This is not exotic: `vue-demo` exposes a global 100–200 % zoom setting
+and pins one app at `zoom: 1.5`.
+
+**Derived-size bookkeeping.** `computedWidth` / `computedHeight` feed
+`--chart-height`, the slotted scales' height and the padding scale factor. They
+must be refreshed whenever `width` / `height` / `fixedAspectRatioScaling`
+change — a ResizeObserver alone is not enough, because a container that changes
+height only never fires one. In `updated()` that refresh runs **before** the
+`hasLabelPadding` branch, since both can change in the same update. And
+`syncScalesAndChart()` returns whether it actually rebuilt: it bails without
+rebuilding when a sync is in flight or the effective chart area is degenerate,
+and the caller's own rebuild is the fallback for those cases.
+
+**Before changing any of this**, open Storybook →
+**Building Blocks → Chart Sizing Battleground**. It renders every chart subject
+across nine container shapes and six zoom levels and prints a PASS/FAIL per
+cell, so a sizing regression is visible rather than inferred.
+
 ### Checklist for Changes:
 
 1. [ ] Read full `chart-line-base.ts` context before editing
@@ -228,6 +286,9 @@ Chart padding has **multiple independent code paths** that must stay in sync. Wh
 5. [ ] Test with both `obc-line-graph` and `obc-area-graph`
 6. [ ] Test with external scales in all slot positions
 7. [ ] Test `obc-gauge-trend` if base class change affects it
+8. [ ] If the change touches sizing or `chart-common.css`, check
+       **Building Blocks → Chart Sizing Battleground** — container shapes,
+       zoom levels and the resize sweep should all stay green
 
 ---
 

--- a/.cursor/rules/testing-visual.mdc
+++ b/.cursor/rules/testing-visual.mdc
@@ -91,6 +91,26 @@ npm run test:visual           # ALWAYS re-run to confirm stability
 - Baselines live in `e2e/visual/__screenshots__/<platform>/` and are
   environment-sensitive in the same way as the core suite.
 
+## Live harness stories (not snapshots)
+
+Some behaviour cannot be pinned by a snapshot because it only appears at a
+container shape, a zoom level or a resize sequence that no single story
+captures. For those there are **live harness stories**: they measure the DOM on
+an interval and print their own PASS/FAIL, and they carry `skip-test` so they
+add no baselines and never run in CI.
+
+- **Building Blocks → Chart Sizing Battleground** — every chart subject
+  (`gauge-trend` in five configurations, line/area graph, `automation-tank` in
+  its chart modes, the bar and gauge building blocks) across nine container
+  shapes, six zoom levels, and a resize sweep that counts distinct rendered
+  sizes per step to catch a layout that rings instead of settling. Check it
+  after any change to chart sizing or `chart-common.css`; see
+  `line-area-charts.md` for the invariants it guards.
+
+When adding one, keep the interval probes per-story and clear them before
+starting new ones — a rerender otherwise leaves two probe loops running and the
+readouts fight each other.
+
 ## Stuck browsers
 
 Spawned Chromium processes sometimes hang and stall a run. Kill the strays and

--- a/.cursor/rules/testing-visual.mdc
+++ b/.cursor/rules/testing-visual.mdc
@@ -97,7 +97,12 @@ Some behaviour cannot be pinned by a snapshot because it only appears at a
 container shape, a zoom level or a resize sequence that no single story
 captures. For those there are **live harness stories**: they measure the DOM on
 an interval and print their own PASS/FAIL, and they carry `skip-test` so they
-add no baselines and never run in CI.
+add no baselines.
+
+`skip-test` is narrower than it sounds — it is a tag exclusion on the Storybook
+**snapshot project** (`tags.exclude` in `vitest.config.ts`) and nothing else.
+These stories are still bundled by `build_storybook`, still type-checked and
+still linted, so a module-scope error in one breaks CI like any other file.
 
 - **Building Blocks → Chart Sizing Battleground** — every chart subject
   (`gauge-trend` in five configurations, line/area graph, `automation-tank` in

--- a/.github/instructions/line-area-charts.instructions.md
+++ b/.github/instructions/line-area-charts.instructions.md
@@ -218,6 +218,64 @@ Chart padding has **multiple independent code paths** that must stay in sync. Wh
 - Advice/setpoint overlays drawn by slotted bars live **outside** the bar band. If you collapse the scale/label band, the bar must reserve a separate advice/setpoint allowance (see `computeAdviceBandThickness` in `external-scale.ts`) — otherwise overlays clip at the SVG edge AND the chart canvas overlaps them because `reportDimensions` returned a thickness too small.
 - Positive-default boolean properties (e.g. `hasLabelPadding = true`, see AGENTS.md § 2) must be declared with `attribute: false`. Pure JS property; framework wrappers handle it transparently.
 
+### Fixed-Aspect Sizing — Invariants That Look Removable But Are Not
+
+`fixedAspectRatioScaling` mode has a specific contract and three CSS
+declarations that each look like tidy-up candidates. Removing any one of them
+silently reintroduces a shipped bug (issue #1138).
+
+**The contract.** `width` / `height` are a **ratio**, not pixels. The component
+fills its container's width and derives its height as
+`measuredWrapperWidth / (width / height)`. The container's available **height
+is never consulted**. So a consumer that wants the chart to fill a box must
+feed that box's measured size back as `width` / `height` — this is what
+`obc-automation-tank` does with a `ResizeObserver` on its chart cell. Leaving
+the 384×384 default in a 900×200 box renders a 900×600 chart that overflows;
+that is the contract working, not a bug.
+
+**The three CSS invariants**, all in `charthelpers/chart-common.css` and all
+scoped to `:host([fixedaspectratioscaling])`:
+
+1. `.canvas-and-slots-container { width: 100% }` — the container must stay a
+   **definite box**. `.wrapper` is a column flex with `align-items: center`, so
+   without this the container is shrink-to-fit; `canvas { width: 100% }` then
+   degrades to `auto`, and a canvas with an auto width and a definite height
+   resolves against its **intrinsic 2:1 ratio** (the 300×150 default). The
+   chart silently caps at `height * 2` and anything wider gets side gutters.
+2. `canvas { margin: 0 }` — Chart.js `getMaximumSize()` **subtracts the
+   canvas' resolved margins** from the container width. `margin: 0 auto`
+   centres the canvas and then donates the leftover space to the margins
+   permanently, so the canvas can never grow into it. Not even an explicit
+   `chart.resize()` recovers.
+3. `canvas { width: 100% !important; height: var(--chart-height) !important }`
+   — the `!important` is load-bearing. Chart.js writes its own measurement back
+   as an inline `style`, and see the measurement rule below for why that number
+   is wrong under `zoom`. Overriding it pins the canvas to the box layout
+   actually gave it; Chart.js keeps its measurement for the drawing buffer,
+   which converges to the same CSS-pixel size (no resolution loss).
+
+**Measurement under CSS `zoom`.** `getBoundingClientRect()` is zoom-scaled;
+`clientWidth` / `clientHeight` and `ResizeObserver` `contentRect` are **not**.
+So never turn a `getBoundingClientRect()` result back into a CSS-pixel style —
+the browser applies the zoom a second time and the element lands at `zoom²` of
+its box. This is not exotic: `vue-demo` exposes a global 100–200 % zoom setting
+and pins one app at `zoom: 1.5`.
+
+**Derived-size bookkeeping.** `computedWidth` / `computedHeight` feed
+`--chart-height`, the slotted scales' height and the padding scale factor. They
+must be refreshed whenever `width` / `height` / `fixedAspectRatioScaling`
+change — a ResizeObserver alone is not enough, because a container that changes
+height only never fires one. In `updated()` that refresh runs **before** the
+`hasLabelPadding` branch, since both can change in the same update. And
+`syncScalesAndChart()` returns whether it actually rebuilt: it bails without
+rebuilding when a sync is in flight or the effective chart area is degenerate,
+and the caller's own rebuild is the fallback for those cases.
+
+**Before changing any of this**, open Storybook →
+**Building Blocks → Chart Sizing Battleground**. It renders every chart subject
+across nine container shapes and six zoom levels and prints a PASS/FAIL per
+cell, so a sizing regression is visible rather than inferred.
+
 ### Checklist for Changes:
 
 1. [ ] Read full `chart-line-base.ts` context before editing
@@ -227,6 +285,9 @@ Chart padding has **multiple independent code paths** that must stay in sync. Wh
 5. [ ] Test with both `obc-line-graph` and `obc-area-graph`
 6. [ ] Test with external scales in all slot positions
 7. [ ] Test `obc-gauge-trend` if base class change affects it
+8. [ ] If the change touches sizing or `chart-common.css`, check
+       **Building Blocks → Chart Sizing Battleground** — container shapes,
+       zoom levels and the resize sweep should all stay green
 
 ---
 

--- a/.github/instructions/line-area-charts.instructions.md
+++ b/.github/instructions/line-area-charts.instructions.md
@@ -230,8 +230,13 @@ fills its container's width and derives its height as
 is never consulted**. So a consumer that wants the chart to fill a box must
 feed that box's measured size back as `width` / `height` — this is what
 `obc-automation-tank` does with a `ResizeObserver` on its chart cell. Leaving
-the 384×384 default in a 900×200 box renders a 900×600 chart that overflows;
-that is the contract working, not a bug.
+the inherited 480×320 default (1.5:1) in a 900×200 box renders a 900×600 chart
+that overflows; that is the contract working, not a bug.
+
+Do not confuse that ratio with `scaleReferenceSize` (default 384). The ratio
+decides the component's own box; `scaleReferenceSize` is the size at which a
+slotted external scale draws 1:1 with the Figma design, and only scales the
+decorations inside it. They are unrelated numbers that both look like sizes.
 
 **The three CSS invariants**, all in `charthelpers/chart-common.css` and all
 scoped to `:host([fixedaspectratioscaling])`:

--- a/.github/instructions/testing-visual.instructions.md
+++ b/.github/instructions/testing-visual.instructions.md
@@ -96,7 +96,12 @@ Some behaviour cannot be pinned by a snapshot because it only appears at a
 container shape, a zoom level or a resize sequence that no single story
 captures. For those there are **live harness stories**: they measure the DOM on
 an interval and print their own PASS/FAIL, and they carry `skip-test` so they
-add no baselines and never run in CI.
+add no baselines.
+
+`skip-test` is narrower than it sounds — it is a tag exclusion on the Storybook
+**snapshot project** (`tags.exclude` in `vitest.config.ts`) and nothing else.
+These stories are still bundled by `build_storybook`, still type-checked and
+still linted, so a module-scope error in one breaks CI like any other file.
 
 - **Building Blocks → Chart Sizing Battleground** — every chart subject
   (`gauge-trend` in five configurations, line/area graph, `automation-tank` in

--- a/.github/instructions/testing-visual.instructions.md
+++ b/.github/instructions/testing-visual.instructions.md
@@ -90,6 +90,26 @@ npm run test:visual           # ALWAYS re-run to confirm stability
 - Baselines live in `e2e/visual/__screenshots__/<platform>/` and are
   environment-sensitive in the same way as the core suite.
 
+## Live harness stories (not snapshots)
+
+Some behaviour cannot be pinned by a snapshot because it only appears at a
+container shape, a zoom level or a resize sequence that no single story
+captures. For those there are **live harness stories**: they measure the DOM on
+an interval and print their own PASS/FAIL, and they carry `skip-test` so they
+add no baselines and never run in CI.
+
+- **Building Blocks → Chart Sizing Battleground** — every chart subject
+  (`gauge-trend` in five configurations, line/area graph, `automation-tank` in
+  its chart modes, the bar and gauge building blocks) across nine container
+  shapes, six zoom levels, and a resize sweep that counts distinct rendered
+  sizes per step to catch a layout that rings instead of settling. Check it
+  after any change to chart sizing or `chart-common.css`; see
+  `line-area-charts.md` for the invariants it guards.
+
+When adding one, keep the interval probes per-story and clear them before
+starting new ones — a rerender otherwise leaves two probe loops running and the
+readouts fight each other.
+
 ## Stuck browsers
 
 Spawned Chromium processes sometimes hang and stall a run. Kill the strays and

--- a/docs/agents/line-area-charts.md
+++ b/docs/agents/line-area-charts.md
@@ -232,8 +232,13 @@ fills its container's width and derives its height as
 is never consulted**. So a consumer that wants the chart to fill a box must
 feed that box's measured size back as `width` / `height` — this is what
 `obc-automation-tank` does with a `ResizeObserver` on its chart cell. Leaving
-the 384×384 default in a 900×200 box renders a 900×600 chart that overflows;
-that is the contract working, not a bug.
+the inherited 480×320 default (1.5:1) in a 900×200 box renders a 900×600 chart
+that overflows; that is the contract working, not a bug.
+
+Do not confuse that ratio with `scaleReferenceSize` (default 384). The ratio
+decides the component's own box; `scaleReferenceSize` is the size at which a
+slotted external scale draws 1:1 with the Figma design, and only scales the
+decorations inside it. They are unrelated numbers that both look like sizes.
 
 **The three CSS invariants**, all in `charthelpers/chart-common.css` and all
 scoped to `:host([fixedaspectratioscaling])`:

--- a/docs/agents/line-area-charts.md
+++ b/docs/agents/line-area-charts.md
@@ -220,6 +220,64 @@ Chart padding has **multiple independent code paths** that must stay in sync. Wh
 - Advice/setpoint overlays drawn by slotted bars live **outside** the bar band. If you collapse the scale/label band, the bar must reserve a separate advice/setpoint allowance (see `computeAdviceBandThickness` in `external-scale.ts`) — otherwise overlays clip at the SVG edge AND the chart canvas overlaps them because `reportDimensions` returned a thickness too small.
 - Positive-default boolean properties (e.g. `hasLabelPadding = true`, see AGENTS.md § 2) must be declared with `attribute: false`. Pure JS property; framework wrappers handle it transparently.
 
+### Fixed-Aspect Sizing — Invariants That Look Removable But Are Not
+
+`fixedAspectRatioScaling` mode has a specific contract and three CSS
+declarations that each look like tidy-up candidates. Removing any one of them
+silently reintroduces a shipped bug (issue #1138).
+
+**The contract.** `width` / `height` are a **ratio**, not pixels. The component
+fills its container's width and derives its height as
+`measuredWrapperWidth / (width / height)`. The container's available **height
+is never consulted**. So a consumer that wants the chart to fill a box must
+feed that box's measured size back as `width` / `height` — this is what
+`obc-automation-tank` does with a `ResizeObserver` on its chart cell. Leaving
+the 384×384 default in a 900×200 box renders a 900×600 chart that overflows;
+that is the contract working, not a bug.
+
+**The three CSS invariants**, all in `charthelpers/chart-common.css` and all
+scoped to `:host([fixedaspectratioscaling])`:
+
+1. `.canvas-and-slots-container { width: 100% }` — the container must stay a
+   **definite box**. `.wrapper` is a column flex with `align-items: center`, so
+   without this the container is shrink-to-fit; `canvas { width: 100% }` then
+   degrades to `auto`, and a canvas with an auto width and a definite height
+   resolves against its **intrinsic 2:1 ratio** (the 300×150 default). The
+   chart silently caps at `height * 2` and anything wider gets side gutters.
+2. `canvas { margin: 0 }` — Chart.js `getMaximumSize()` **subtracts the
+   canvas' resolved margins** from the container width. `margin: 0 auto`
+   centres the canvas and then donates the leftover space to the margins
+   permanently, so the canvas can never grow into it. Not even an explicit
+   `chart.resize()` recovers.
+3. `canvas { width: 100% !important; height: var(--chart-height) !important }`
+   — the `!important` is load-bearing. Chart.js writes its own measurement back
+   as an inline `style`, and see the measurement rule below for why that number
+   is wrong under `zoom`. Overriding it pins the canvas to the box layout
+   actually gave it; Chart.js keeps its measurement for the drawing buffer,
+   which converges to the same CSS-pixel size (no resolution loss).
+
+**Measurement under CSS `zoom`.** `getBoundingClientRect()` is zoom-scaled;
+`clientWidth` / `clientHeight` and `ResizeObserver` `contentRect` are **not**.
+So never turn a `getBoundingClientRect()` result back into a CSS-pixel style —
+the browser applies the zoom a second time and the element lands at `zoom²` of
+its box. This is not exotic: `vue-demo` exposes a global 100–200 % zoom setting
+and pins one app at `zoom: 1.5`.
+
+**Derived-size bookkeeping.** `computedWidth` / `computedHeight` feed
+`--chart-height`, the slotted scales' height and the padding scale factor. They
+must be refreshed whenever `width` / `height` / `fixedAspectRatioScaling`
+change — a ResizeObserver alone is not enough, because a container that changes
+height only never fires one. In `updated()` that refresh runs **before** the
+`hasLabelPadding` branch, since both can change in the same update. And
+`syncScalesAndChart()` returns whether it actually rebuilt: it bails without
+rebuilding when a sync is in flight or the effective chart area is degenerate,
+and the caller's own rebuild is the fallback for those cases.
+
+**Before changing any of this**, open Storybook →
+**Building Blocks → Chart Sizing Battleground**. It renders every chart subject
+across nine container shapes and six zoom levels and prints a PASS/FAIL per
+cell, so a sizing regression is visible rather than inferred.
+
 ### Checklist for Changes:
 
 1. [ ] Read full `chart-line-base.ts` context before editing
@@ -229,6 +287,9 @@ Chart padding has **multiple independent code paths** that must stay in sync. Wh
 5. [ ] Test with both `obc-line-graph` and `obc-area-graph`
 6. [ ] Test with external scales in all slot positions
 7. [ ] Test `obc-gauge-trend` if base class change affects it
+8. [ ] If the change touches sizing or `chart-common.css`, check
+       **Building Blocks → Chart Sizing Battleground** — container shapes,
+       zoom levels and the resize sweep should all stay green
 
 ---
 

--- a/docs/agents/testing-visual.md
+++ b/docs/agents/testing-visual.md
@@ -91,6 +91,26 @@ npm run test:visual           # ALWAYS re-run to confirm stability
 - Baselines live in `e2e/visual/__screenshots__/<platform>/` and are
   environment-sensitive in the same way as the core suite.
 
+## Live harness stories (not snapshots)
+
+Some behaviour cannot be pinned by a snapshot because it only appears at a
+container shape, a zoom level or a resize sequence that no single story
+captures. For those there are **live harness stories**: they measure the DOM on
+an interval and print their own PASS/FAIL, and they carry `skip-test` so they
+add no baselines and never run in CI.
+
+- **Building Blocks → Chart Sizing Battleground** — every chart subject
+  (`gauge-trend` in five configurations, line/area graph, `automation-tank` in
+  its chart modes, the bar and gauge building blocks) across nine container
+  shapes, six zoom levels, and a resize sweep that counts distinct rendered
+  sizes per step to catch a layout that rings instead of settling. Check it
+  after any change to chart sizing or `chart-common.css`; see
+  `line-area-charts.md` for the invariants it guards.
+
+When adding one, keep the interval probes per-story and clear them before
+starting new ones — a rerender otherwise leaves two probe loops running and the
+readouts fight each other.
+
 ## Stuck browsers
 
 Spawned Chromium processes sometimes hang and stall a run. Kill the strays and

--- a/docs/agents/testing-visual.md
+++ b/docs/agents/testing-visual.md
@@ -97,7 +97,12 @@ Some behaviour cannot be pinned by a snapshot because it only appears at a
 container shape, a zoom level or a resize sequence that no single story
 captures. For those there are **live harness stories**: they measure the DOM on
 an interval and print their own PASS/FAIL, and they carry `skip-test` so they
-add no baselines and never run in CI.
+add no baselines.
+
+`skip-test` is narrower than it sounds — it is a tag exclusion on the Storybook
+**snapshot project** (`tags.exclude` in `vitest.config.ts`) and nothing else.
+These stories are still bundled by `build_storybook`, still type-checked and
+still linted, so a module-scope error in one breaks CI like any other file.
 
 - **Building Blocks → Chart Sizing Battleground** — every chart subject
   (`gauge-trend` in five configurations, line/area graph, `automation-tank` in

--- a/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-line-base.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-line-base.ts
@@ -1678,6 +1678,24 @@ export class ObcChartLineBase extends LitElement {
       return;
     }
 
+    // `computedWidth` / `computedHeight` are the pixel size everything below
+    // derives from (`--chart-height`, the slotted scales' height, the padding
+    // scale factor). They were only ever refreshed from the wrapper's
+    // ResizeObserver, so re-assigning `width` / `height` rebuilt the chart
+    // against the *previous* aspect ratio and the new one only took effect on
+    // the next container resize (issue #1138).
+    //
+    // This runs before the `hasLabelPadding` branch below: the two can change
+    // in the same update (the tank sets both on its embedded gauge-trend), and
+    // taking the label-padding path first would rebuild against a stale
+    // derived size. Nothing is lost by going through here instead — a rebuild
+    // from `updateComputedDimensions()` goes via `syncScalesAndChart()`, which
+    // performs the same `updateScaleProperties()` cascade.
+    if (this.hasAnyChanged(changed, LINE_GRAPH_DIMENSION_PROP_NAMES)) {
+      // Recreates the chart itself when the derived size actually moved.
+      if (this.updateComputedDimensions()) return;
+    }
+
     // `hasLabelPadding` cascades into slotted scales via `updateScaleProperties()`
     // (toggles `showLabels`, which collapses/expands the bar's label band and
     // changes its reported thickness). That path only runs through
@@ -1687,17 +1705,6 @@ export class ObcChartLineBase extends LitElement {
     if (changed.has('hasLabelPadding') && this.hasExternalScales()) {
       this.syncScalesAndChart();
       return;
-    }
-
-    // `computedWidth` / `computedHeight` are the pixel size everything below
-    // derives from (`--chart-height`, the slotted scales' height, the padding
-    // scale factor). They were only ever refreshed from the wrapper's
-    // ResizeObserver, so re-assigning `width` / `height` rebuilt the chart
-    // against the *previous* aspect ratio and the new one only took effect on
-    // the next container resize (issue #1138).
-    if (this.hasAnyChanged(changed, LINE_GRAPH_DIMENSION_PROP_NAMES)) {
-      // Recreates the chart itself when the derived size actually moved.
-      if (this.updateComputedDimensions()) return;
     }
 
     const needsRecreation = this.hasAnyChanged(
@@ -1811,8 +1818,13 @@ export class ObcChartLineBase extends LitElement {
   }
 
   /**
-   * Calculate actual dimensions based on parent width and aspect ratio.
-   * Only used when fixedAspectRatioScaling is true.
+   * Refresh `computedWidth` / `computedHeight`, the derived pixel size the
+   * chart and its slotted scales are laid out from.
+   *
+   * In pixel mode they simply mirror `width` / `height`. Only in
+   * `fixedAspectRatioScaling` mode are they derived — from the wrapper's
+   * measured width and the aspect ratio the `width` / `height` pair defines —
+   * and only then can this rebuild the chart.
    *
    * @returns `true` when the change was significant enough that the chart was
    * rebuilt here, so the caller must not rebuild it a second time.

--- a/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-line-base.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-line-base.ts
@@ -182,6 +182,16 @@ const LINE_GRAPH_RECREATE_PROP_NAMES = [
 ] as const;
 
 /**
+ * Properties that define the chart's reference size, and therefore invalidate
+ * the derived `computedWidth` / `computedHeight` pair.
+ */
+const LINE_GRAPH_DIMENSION_PROP_NAMES = [
+  'width',
+  'height',
+  'fixedAspectRatioScaling',
+] as const;
+
+/**
  * Abstract base class for line and area chart components built on Chart.js.
  *
  * ## Features
@@ -1678,6 +1688,17 @@ export class ObcChartLineBase extends LitElement {
       return;
     }
 
+    // `computedWidth` / `computedHeight` are the pixel size everything below
+    // derives from (`--chart-height`, the slotted scales' height, the padding
+    // scale factor). They were only ever refreshed from the wrapper's
+    // ResizeObserver, so re-assigning `width` / `height` rebuilt the chart
+    // against the *previous* aspect ratio and the new one only took effect on
+    // the next container resize (issue #1138).
+    if (this.hasAnyChanged(changed, LINE_GRAPH_DIMENSION_PROP_NAMES)) {
+      // Recreates the chart itself when the derived size actually moved.
+      if (this.updateComputedDimensions()) return;
+    }
+
     const needsRecreation = this.hasAnyChanged(
       changed,
       LINE_GRAPH_RECREATE_PROP_NAMES
@@ -1791,22 +1812,25 @@ export class ObcChartLineBase extends LitElement {
   /**
    * Calculate actual dimensions based on parent width and aspect ratio.
    * Only used when fixedAspectRatioScaling is true.
+   *
+   * @returns `true` when the change was significant enough that the chart was
+   * rebuilt here, so the caller must not rebuild it a second time.
    */
-  private updateComputedDimensions() {
+  private updateComputedDimensions(): boolean {
     if (!this.fixedAspectRatioScaling) {
       // In pixel mode, use width/height directly
       this.computedWidth = this.width;
       this.computedHeight = this.height;
-      return;
+      return false;
     }
 
     // Get the wrapper element
     const wrapper = this.renderRoot.querySelector('.wrapper') as HTMLElement;
-    if (!wrapper) return;
+    if (!wrapper) return false;
 
     // Get parent's available width
     const parentWidth = wrapper.clientWidth;
-    if (parentWidth <= 0) return;
+    if (parentWidth <= 0) return false;
 
     // Calculate aspect ratio from width/height properties
     const aspectRatio = this.width / this.height;
@@ -1837,12 +1861,15 @@ export class ObcChartLineBase extends LitElement {
       // so we only call createChart() directly when there are no external scales.
       if (this.hasExternalScales()) {
         this.syncScalesAndChart();
+        return true;
       } else if (this.chart) {
         // No external scales - just recreate chart
         this.chart.destroy();
         this.createChart();
+        return true;
       }
     }
+    return false;
   }
 
   /**

--- a/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-line-base.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-line-base.ts
@@ -1274,8 +1274,8 @@ export class ObcChartLineBase extends LitElement {
    * Synchronize scale and chart dimensions/data
    * This is the main coordination function
    */
-  private syncScalesAndChart() {
-    if (this.isUpdatingScales) return;
+  private syncScalesAndChart(): boolean {
+    if (this.isUpdatingScales) return false;
     this.isUpdatingScales = true;
 
     // console.debug(`[chart-line-base] Syncing scales and chart`, {
@@ -1308,7 +1308,7 @@ export class ObcChartLineBase extends LitElement {
           effectiveWidth,
           effectiveHeight,
         });
-        return;
+        return false;
       }
 
       // Step 3: Update slotted scales with coordinated properties
@@ -1320,6 +1320,7 @@ export class ObcChartLineBase extends LitElement {
         this.chart.destroy();
       }
       this.createChart();
+      return true;
     } finally {
       this.isUpdatingScales = false;
     }
@@ -1860,8 +1861,10 @@ export class ObcChartLineBase extends LitElement {
       // Note: syncScalesAndChart() handles chart destruction and creation internally,
       // so we only call createChart() directly when there are no external scales.
       if (this.hasExternalScales()) {
-        this.syncScalesAndChart();
-        return true;
+        // syncScalesAndChart() bails without rebuilding when a sync is already
+        // in flight or the effective chart area is degenerate; reporting its
+        // real outcome keeps the caller's own rebuild as the fallback.
+        return this.syncScalesAndChart();
       } else if (this.chart) {
         // No external scales - just recreate chart
         this.chart.destroy();

--- a/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-sizing-battleground.stories.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-sizing-battleground.stories.ts
@@ -1,0 +1,598 @@
+import type {Meta, StoryObj} from '@storybook/web-components-vite';
+import {html, type TemplateResult} from 'lit';
+import {ref} from 'lit/directives/ref.js';
+import '../../bars-graphs/line-graph/line-graph.js';
+import '../../bars-graphs/area-graph/area-graph.js';
+import '../../navigation-instruments/gauge-trend/gauge-trend.js';
+import '../../navigation-instruments/gauge-vertical/gauge-vertical.js';
+import '../../navigation-instruments/gauge-horizontal/gauge-horizontal.js';
+import '../bar-vertical/bar-vertical.js';
+import '../bar-horizontal/bar-horizontal.js';
+import '../../automation/automation-tank/automation-tank.js';
+import {AdviceType} from '../../navigation-instruments/watch/advice.js';
+
+const DATA = Array.from({length: 12}, (_, i) => ({
+  label: String(i),
+  value: 40 + 30 * Math.sin(i / 2),
+}));
+
+/**
+ * How a subject is expected to size itself.
+ *
+ * - `fills`: told the cell's measured size as its aspect-ratio reference (the
+ *   integration `obc-automation-tank` uses), so its painted surface must cover
+ *   the cell exactly.
+ * - `intrinsic`: owns its size by design — the fixed-config gauges, and any
+ *   chart in pixel mode. Only checked for layout stability.
+ */
+enum SizingContract {
+  /** Must cover the box it was given. */
+  fills = 'fills',
+  /** Owns its size; only checked for stability. */
+  intrinsic = 'intrinsic',
+}
+
+interface Subject {
+  label: string;
+  contract: SizingContract;
+  /**
+   * Whether the harness must hand this subject the cell's measured size as its
+   * aspect-ratio reference. The tanks measure their own chart cell internally,
+   * so they are driven by the cell alone.
+   */
+  feedsSize?: boolean;
+  render: () => TemplateResult;
+}
+
+interface Shape {
+  label: string;
+  outer: string;
+  inner: string;
+  /** Cells this small are below the components' min-content size. */
+  degenerate?: boolean;
+}
+
+const FILL_STYLE = 'position:absolute;inset:0';
+
+const SHAPES: Shape[] = [
+  {label: '1.5:1', outer: '', inner: 'width:300px;height:200px'},
+  {label: '1:1', outer: '', inner: 'width:240px;height:240px'},
+  {label: '3:1', outer: '', inner: 'width:480px;height:160px'},
+  {label: '6:1', outer: '', inner: 'width:600px;height:100px'},
+  {label: '1:2', outer: '', inner: 'width:160px;height:320px'},
+  {
+    label: 'flex min/max + centred',
+    outer: 'display:flex;width:420px;height:220px;align-items:center',
+    inner: 'flex:1;min-height:150px;max-height:190px;align-self:center',
+  },
+  {
+    label: 'grid track',
+    outer:
+      'display:grid;grid-template-columns:1fr 1fr;width:480px;height:200px',
+    inner: 'min-width:0;min-height:0',
+  },
+  {
+    label: 'aspect-ratio only',
+    outer: '',
+    inner: 'width:300px;aspect-ratio:2/1',
+  },
+  {
+    label: 'tiny',
+    outer: '',
+    inner: 'width:120px;height:90px',
+    degenerate: true,
+  },
+];
+
+const SUBJECTS: Subject[] = [
+  {
+    label: 'gauge-trend',
+    contract: SizingContract.fills,
+    feedsSize: true,
+    render: () =>
+      html`<obc-gauge-trend
+        style=${FILL_STYLE}
+        .data=${DATA}
+        .minValue=${0}
+        .maxValue=${100}
+        .value=${55}
+        .chartFill=${true}
+        .hasLabelPadding=${false}
+      ></obc-gauge-trend>`,
+  },
+  {
+    label: 'gauge-trend + bar + scale',
+    contract: SizingContract.fills,
+    feedsSize: true,
+    render: () =>
+      html`<obc-gauge-trend
+        style=${FILL_STYLE}
+        .data=${DATA}
+        .minValue=${0}
+        .maxValue=${100}
+        .value=${55}
+        .chartFill=${true}
+        .hasBar=${true}
+        .hasScale=${true}
+        .primaryTickmarkInterval=${25}
+      ></obc-gauge-trend>`,
+  },
+  {
+    label: 'gauge-trend + advice + setpoint',
+    contract: SizingContract.fills,
+    feedsSize: true,
+    render: () =>
+      html`<obc-gauge-trend
+        style=${FILL_STYLE}
+        .data=${DATA}
+        .minValue=${0}
+        .maxValue=${100}
+        .value=${55}
+        .chartFill=${true}
+        .hasBar=${true}
+        .hasAdvice=${true}
+        .advice=${[
+          {min: 75, max: 100, type: AdviceType.caution, hinted: false},
+        ]}
+        .setpoint=${70}
+        .hasLabelPadding=${false}
+      ></obc-gauge-trend>`,
+  },
+  {
+    label: 'line-graph (aspect)',
+    contract: SizingContract.fills,
+    feedsSize: true,
+    render: () =>
+      html`<obc-line-graph
+        style=${FILL_STYLE}
+        .data=${DATA}
+        .fixedAspectRatioScaling=${true}
+        .hasLabelPadding=${false}
+      ></obc-line-graph>`,
+  },
+  {
+    label: 'area-graph (aspect)',
+    contract: SizingContract.fills,
+    feedsSize: true,
+    render: () =>
+      html`<obc-area-graph
+        style=${FILL_STYLE}
+        .data=${DATA}
+        .fixedAspectRatioScaling=${true}
+        .hasLabelPadding=${false}
+      ></obc-area-graph>`,
+  },
+  {
+    label: 'tank graph-and-bar',
+    contract: SizingContract.fills,
+    render: () =>
+      html`<obc-automation-tank
+        style=${FILL_STYLE}
+        chart-mode="graph-and-bar"
+        .chartData=${DATA}
+        .value=${62}
+        .max=${100}
+        tag="TK"
+      ></obc-automation-tank>`,
+  },
+  {
+    label: 'tank graph horizontal',
+    contract: SizingContract.fills,
+    render: () =>
+      html`<obc-automation-tank
+        style=${FILL_STYLE}
+        chart-mode="graph"
+        orientation="horizontal"
+        .chartData=${DATA}
+        .value=${62}
+        .max=${100}
+        tag="TK"
+      ></obc-automation-tank>`,
+  },
+  {
+    label: 'tank bar mode',
+    contract: SizingContract.fills,
+    render: () =>
+      html`<obc-automation-tank
+        style=${FILL_STYLE}
+        chart-mode="bar"
+        .value=${62}
+        .max=${100}
+        tag="TK"
+      ></obc-automation-tank>`,
+  },
+  {
+    label: 'tank compact',
+    contract: SizingContract.fills,
+    render: () =>
+      html`<obc-automation-tank
+        style=${FILL_STYLE}
+        chart-mode="graph-and-bar"
+        compact
+        .chartData=${DATA}
+        .value=${62}
+        .max=${100}
+        tag="TK"
+      ></obc-automation-tank>`,
+  },
+  {
+    label: 'line-graph (pixel mode)',
+    contract: SizingContract.intrinsic,
+    render: () =>
+      html`<obc-line-graph
+        .data=${DATA}
+        .width=${240}
+        .height=${160}
+      ></obc-line-graph>`,
+  },
+  {
+    label: 'bar-vertical',
+    contract: SizingContract.intrinsic,
+    render: () =>
+      html`<obc-bar-vertical
+        .minValue=${0}
+        .maxValue=${100}
+        .value=${55}
+        .hasBar=${true}
+        .hasScale=${true}
+        .primaryTickmarkInterval=${25}
+        .fixedAspectRatio=${true}
+      ></obc-bar-vertical>`,
+  },
+  {
+    label: 'gauge-vertical',
+    contract: SizingContract.intrinsic,
+    render: () =>
+      html`<obc-gauge-vertical
+        .minValue=${0}
+        .maxValue=${100}
+        .value=${55}
+        .primaryTickmarkInterval=${25}
+      ></obc-gauge-vertical>`,
+  },
+];
+
+/**
+ * The painted surface to compare against the cell. For the tank that is the
+ * canvas (or bar SVG) inside its chart cell, so the tank's own frame, readout
+ * and tag are excluded; for everything else it is the component's own canvas
+ * or SVG measured against the component box.
+ */
+function paintedSurface(
+  el: Element
+): {box: Element; paint: Element} | undefined {
+  const shadow = (el as HTMLElement).shadowRoot;
+  if (el.tagName === 'OBC-AUTOMATION-TANK') {
+    const cell = shadow?.querySelector('.bar-container');
+    const paint =
+      shadow
+        ?.querySelector('obc-gauge-trend')
+        ?.shadowRoot?.querySelector('canvas') ??
+      shadow?.querySelector('obc-bar-vertical svg, obc-bar-horizontal svg');
+    return cell && paint ? {box: cell, paint} : undefined;
+  }
+  const paint =
+    shadow?.querySelector('canvas') ??
+    shadow?.querySelector('svg') ??
+    el.querySelector('svg');
+  return paint ? {box: el, paint} : undefined;
+}
+
+/**
+ * The box the host reserved for a chart, when the subject is a host rather
+ * than a chart itself. Used to tell "no room was given" apart from "room was
+ * given and nothing rendered into it".
+ */
+function hostChartBox(el: Element): DOMRect | undefined {
+  if (el.tagName !== 'OBC-AUTOMATION-TANK') return undefined;
+  const cell = (el as HTMLElement).shadowRoot?.querySelector('.bar-container');
+  return cell?.getBoundingClientRect();
+}
+
+const sizeHistory = new WeakMap<Element, Set<string>>();
+const sizeFed = new WeakSet<Element>();
+
+function trackStability(el: Element) {
+  if (sizeHistory.has(el)) return;
+  const seen = new Set<string>();
+  sizeHistory.set(el, seen);
+  new ResizeObserver((entries) => {
+    const entry = entries[0];
+    if (!entry) return;
+    seen.add(
+      `${Math.round(entry.contentRect.width)}x${Math.round(entry.contentRect.height)}`
+    );
+  }).observe(el);
+}
+
+/**
+ * Feed the measured cell size back to the subject as its aspect-ratio
+ * reference. This is what `obc-automation-tank` does internally for its own
+ * chart cell, and it is the integration the `fills` contract is defined
+ * against — a bare chart is never expected to guess its container's shape.
+ */
+function feedCellSize(cell: HTMLElement, subject: Element) {
+  if (sizeFed.has(subject)) return;
+  sizeFed.add(subject);
+  const target = subject as unknown as {width: number; height: number};
+  new ResizeObserver((entries) => {
+    const entry = entries[0];
+    if (!entry) return;
+    const w = Math.round(entry.contentRect.width);
+    const h = Math.round(entry.contentRect.height);
+    if (w > 0 && h > 0) {
+      target.width = w;
+      target.height = h;
+    }
+  }).observe(cell);
+}
+
+/**
+ * Attach live measurement to one rendered battleground and repaint verdicts.
+ * Each battleground gets its own callback so that unmounting one does not tear
+ * down the probes of its siblings.
+ */
+function createMeasure(): (root?: Element) => void {
+  let probe: number | undefined;
+  return (root?: Element) => {
+    if (!(root instanceof HTMLElement)) {
+      if (probe !== undefined) clearInterval(probe);
+      probe = undefined;
+      return;
+    }
+
+    const paint = () => {
+      let pass = 0;
+      let total = 0;
+      root.querySelectorAll<HTMLElement>('[data-cell]').forEach((cell) => {
+        const subject = cell.firstElementChild;
+        const readout = cell
+          .closest<HTMLElement>('[data-case]')
+          ?.querySelector<HTMLElement>('[data-readout]');
+        if (!subject || !readout) return;
+
+        // Wired from here rather than once up front: the `ref` callback runs
+        // before the template's child parts commit, so at that point the cells
+        // do not exist yet. Both helpers are idempotent.
+        trackStability(subject);
+        if (cell.dataset.feed === 'true') feedCellSize(cell, subject);
+
+        const contract = cell.dataset.contract as SizingContract;
+        const distinct = sizeHistory.get(subject)?.size ?? 0;
+        const surface = paintedSurface(subject);
+        const hostBox = hostChartBox(subject);
+
+        // A host that gave its chart no room at all (a tank squeezed below the
+        // height its badges, readout and tag need) cannot be held to the fill
+        // contract. Reported rather than hidden, and kept distinct from "the
+        // box has room but nothing rendered into it", which is a real failure.
+        if (hostBox && hostBox.width * hostBox.height < 1) {
+          readout.textContent = 'host left no room for a chart  (n/a)';
+          readout.style.color = 'var(--element-neutral-color)';
+          return;
+        }
+
+        if (!surface) {
+          total += 1;
+          readout.textContent = 'box has room but nothing rendered  FAIL';
+          readout.style.color = 'var(--alert-alarm-color)';
+          return;
+        }
+
+        const box = surface.box.getBoundingClientRect();
+        const px = surface.paint.getBoundingClientRect();
+        const fill =
+          box.width * box.height > 0
+            ? (px.width * px.height) / (box.width * box.height)
+            : 0;
+        const overflow = Math.max(px.width - box.width, px.height - box.height);
+        const stable = distinct <= 1;
+        const enforced = contract === SizingContract.fills;
+        const ok = stable && (!enforced || (fill >= 0.99 && overflow <= 1));
+
+        total += 1;
+        if (ok) pass += 1;
+
+        readout.textContent =
+          `cell ${Math.round(box.width)}×${Math.round(box.height)}` +
+          `  paint ${Math.round(px.width)}×${Math.round(px.height)}` +
+          `  fills ${(fill * 100).toFixed(0)}%` +
+          `  sizes ${distinct}` +
+          (enforced ? (ok ? '  PASS' : '  FAIL') : '  (intrinsic)');
+        readout.style.color = ok
+          ? 'var(--element-neutral-color)'
+          : 'var(--alert-alarm-color)';
+      });
+
+      const summary = root.querySelector<HTMLElement>('[data-summary]');
+      if (summary) {
+        summary.textContent = `${pass} / ${total} cells pass`;
+        summary.style.color =
+          pass === total
+            ? 'var(--element-neutral-color)'
+            : 'var(--alert-alarm-color)';
+      }
+    };
+
+    paint();
+    probe = window.setInterval(paint, 500);
+  };
+}
+
+const MONO =
+  'font:11px/1.5 monospace;color:var(--element-neutral-color);white-space:pre';
+
+function cellFor(shape: Shape, subject: Subject): TemplateResult {
+  const contract = shape.degenerate
+    ? SizingContract.intrinsic
+    : subject.contract;
+  return html`
+    <div data-case style="margin:0 12px 12px 0">
+      <div style=${MONO}>${shape.label} · ${subject.label}</div>
+      <div data-readout style=${MONO}>measuring…</div>
+      <div style=${shape.outer}>
+        <div
+          data-cell
+          data-feed=${String(!!subject.feedsSize)}
+          data-contract=${contract}
+          style="position:relative;overflow:hidden;outline:1px dashed var(--border-divider-color);${shape.inner}"
+        >
+          ${subject.render()}
+        </div>
+        ${shape.outer.includes('grid') ? html`<div></div>` : null}
+      </div>
+    </div>
+  `;
+}
+
+function battleground(
+  shapes: Shape[],
+  subjects: Subject[],
+  zoom = 1
+): TemplateResult {
+  return html`
+    <div ${ref(createMeasure())}>
+      <div
+        data-summary
+        style="font:14px monospace;padding:8px 0;position:sticky;top:0;background:var(--container-background-color);z-index:2"
+      >
+        measuring…
+      </div>
+      <div style=${zoom === 1 ? '' : `zoom:${zoom}`}>
+        <div style="display:flex;flex-wrap:wrap;align-items:flex-start">
+          ${subjects.flatMap((s) => shapes.map((shape) => cellFor(shape, s)))}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+const meta: Meta = {
+  title: 'Building Blocks/Chart Sizing Battleground',
+  tags: ['skip-test'],
+  parameters: {
+    controls: {disable: true},
+    docs: {
+      description: {
+        component:
+          'A live matrix for the chart sizing contract. Every cell measures ' +
+          'its own painted surface against the box it was given and prints a ' +
+          'verdict, so a sizing regression shows up as a red FAIL rather than ' +
+          'as an impression. Subjects marked `(intrinsic)` own their size by ' +
+          'design and are only checked for layout stability — `sizes` counts ' +
+          'the distinct rendered sizes a `ResizeObserver` has seen, so ' +
+          'anything above 1 after settling means the layout is ringing.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+/**
+ * Every subject in every container shape. `fills` subjects are fed the cell's
+ * measured size as their aspect-ratio reference — the integration
+ * `obc-automation-tank` uses — so their painted surface must cover the cell.
+ *
+ * The wide shapes (`3:1`, `6:1`) are the ones that regressed in issue #1138:
+ * the canvas could not exceed twice its own height, so the remainder showed up
+ * as symmetric empty margins.
+ *
+ * One cell is expected to be red: `1:2 · tank graph horizontal`. A horizontal
+ * tank in a portrait box gets a 30px-wide chart cell, below the width its own
+ * layout needs, so the chart overflows it. That is a tank layout limit rather
+ * than a chart sizing one — it predates #1138 and is unchanged by its fix.
+ */
+export const ContainerShapes: Story = {
+  render: () => battleground(SHAPES, SUBJECTS),
+};
+
+/**
+ * A representative subject set repeated under CSS `zoom`. A global
+ * `html { zoom: … }` is how a fixed layout is fitted to a display — the
+ * `vue-demo` exposes exactly that as a user setting — so every level here is a
+ * shape real deployments run in.
+ *
+ * Both halves of the double-application are covered: below 1 the canvas used
+ * to shrink to `zoom²` of its cell, above 1 it used to overflow by the same
+ * factor.
+ */
+export const ZoomLevels: Story = {
+  render: () => {
+    const subjects = SUBJECTS.filter((s) =>
+      [
+        'gauge-trend',
+        'gauge-trend + bar + scale',
+        'tank graph-and-bar',
+        'area-graph (aspect)',
+      ].includes(s.label)
+    );
+    const shapes = SHAPES.filter((s) => ['1.5:1', '3:1'].includes(s.label));
+    return html`${[0.5, 0.8, 1, 1.25, 1.5, 2].map(
+      (zoom) => html`
+        <h3
+          style="font:600 13px monospace;color:var(--element-active-color);margin:16px 0 4px"
+        >
+          zoom ${zoom}
+        </h3>
+        ${battleground(shapes, subjects, zoom)}
+      `
+    )}`;
+  },
+};
+
+/**
+ * Drives each cell through a sweep of sizes and keeps counting distinct
+ * rendered sizes. A settled layout converges to one size per step; a circular
+ * constraint between a component and the box that measures it shows up here as
+ * a `sizes` count that keeps climbing (issue #1121).
+ */
+export const ResizeStress: Story = {
+  render: () => {
+    const subjects = SUBJECTS.filter((s) =>
+      [
+        'gauge-trend + bar + scale',
+        'tank graph-and-bar',
+        'tank graph horizontal',
+        'line-graph (aspect)',
+      ].includes(s.label)
+    );
+    const shape: Shape = {
+      label: 'Animated',
+      outer: '',
+      inner: 'width:300px;height:200px',
+    };
+    const createdMeasure = createMeasure();
+    let timer: number | undefined;
+    const drive = (root?: Element) => {
+      createdMeasure(root);
+      if (!(root instanceof HTMLElement)) {
+        if (timer !== undefined) clearInterval(timer);
+        timer = undefined;
+        return;
+      }
+      const steps = [
+        [300, 200],
+        [300, 340],
+        [520, 340],
+        [520, 140],
+        [180, 140],
+      ];
+      let i = 0;
+      timer = window.setInterval(() => {
+        const [w, h] = steps[i++ % steps.length];
+        root.querySelectorAll<HTMLElement>('[data-cell]').forEach((cell) => {
+          cell.style.width = `${w}px`;
+          cell.style.height = `${h}px`;
+          // The size count is per step: the question is whether the layout
+          // settles on ONE size for the box it was just given, not how many
+          // boxes the sweep has been through.
+          const subject = cell.firstElementChild;
+          if (subject) sizeHistory.get(subject)?.clear();
+        });
+      }, 1200);
+    };
+    return html`<div ${ref(drive)}>${battleground([shape], subjects)}</div>`;
+  },
+};

--- a/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-sizing-battleground.stories.ts
+++ b/packages/openbridge-webcomponents/src/building-blocks/chart-line/chart-sizing-battleground.stories.ts
@@ -335,11 +335,12 @@ function feedCellSize(cell: HTMLElement, subject: Element) {
 function createMeasure(): (root?: Element) => void {
   let probe: number | undefined;
   return (root?: Element) => {
-    if (!(root instanceof HTMLElement)) {
-      if (probe !== undefined) clearInterval(probe);
-      probe = undefined;
-      return;
-    }
+    // Cleared unconditionally, not only on unmount: a re-invocation with a
+    // mounted root (a rerender, or HMR) would otherwise leave the previous
+    // interval running forever alongside the new one.
+    if (probe !== undefined) clearInterval(probe);
+    probe = undefined;
+    if (!(root instanceof HTMLElement)) return;
 
     const paint = () => {
       let pass = 0;
@@ -567,11 +568,11 @@ export const ResizeStress: Story = {
     let timer: number | undefined;
     const drive = (root?: Element) => {
       createdMeasure(root);
-      if (!(root instanceof HTMLElement)) {
-        if (timer !== undefined) clearInterval(timer);
-        timer = undefined;
-        return;
-      }
+      // Same reasoning as createMeasure(): clear before starting, so a
+      // rerender cannot leave two sweeps fighting over the same cells.
+      if (timer !== undefined) clearInterval(timer);
+      timer = undefined;
+      if (!(root instanceof HTMLElement)) return;
       const steps = [
         [300, 200],
         [300, 340],

--- a/packages/openbridge-webcomponents/src/charthelpers/chart-common.css
+++ b/packages/openbridge-webcomponents/src/charthelpers/chart-common.css
@@ -35,8 +35,32 @@ canvas {
   display: block;
 }
 
-/* Fixed aspect ratio scaling mode: canvas fills wrapper */
-:host([fixedaspectratioscaling]) canvas {
+/* Fixed aspect ratio scaling mode: the canvas container must be a definite
+   box, not shrink-to-fit. The wrapper is a column flex with align-items:
+   center, so the container would otherwise size to the canvas' max-content
+   width — and a canvas with an auto width and a definite height resolves
+   against its intrinsic 2:1 ratio, capping the chart at height * 2. */
+:host([fixedaspectratioscaling]) .canvas-and-slots-container {
   width: 100%;
-  height: var(--chart-height, auto);
+}
+
+/* Fixed aspect ratio scaling mode: canvas fills wrapper.
+
+   `!important` is load-bearing, not a shortcut. Chart.js measures the
+   container with getBoundingClientRect() — which is scaled by any ancestor
+   CSS `zoom` — and writes that number straight back as an inline
+   `style="width/height: Npx"`. The browser then scales that CSS-pixel value
+   by the same zoom a second time, so the canvas lands at zoom² of its cell
+   (64% at zoom 0.8, 156% at zoom 1.25). Overriding the inline style pins the
+   canvas to the box the layout actually gave it at every zoom level; Chart.js
+   keeps using its own measurement for the drawing buffer, which only affects
+   raster resolution, not geometry.
+
+   No auto margins here either: Chart.js subtracts the canvas' resolved
+   margins from the container width, so centring it with `margin: 0 auto`
+   makes the leftover space permanently unavailable to it. */
+:host([fixedaspectratioscaling]) canvas {
+  width: 100% !important;
+  height: var(--chart-height, auto) !important;
+  margin: 0;
 }


### PR DESCRIPTION
Fixes #1138.

Three independent defects, all in `fixedAspectRatioScaling` mode, all surfacing as whitespace around the chart. Only `obc-gauge-trend` turns that mode on by default ([`gauge-trend.ts:155`](../blob/develop/packages/openbridge-webcomponents/src/navigation-instruments/gauge-trend/gauge-trend.ts#L155)) — which is why @reach-mvbj saw it on the tank's graph and nowhere else. Every other instrument is SVG (no canvas, no Chart.js measurement); the circular charts never enable the flag; `line-graph` / `area-graph` are affected only when a consumer opts in.

It is not the consumer's CSS. Their layout only supplies the trigger — a cell wider than 2:1, a height-only resize, or a zoomed ancestor.

## Root causes

### 1. The canvas could never exceed `height × 2`

Measured on `develop`, with cells at a definite pixel size and the gauge told the matching `width`/`height`:

| host box | canvas | unused width |
|---|---|---|
| 900×150 | 300×150 | 600 |
| 900×300 | 600×300 | 300 |
| 1200×200 | 400×200 | 800 |
| 250×200 | 250×200 | 0 |

Exactly `min(hostWidth, 2 × height)`. This is CSS, not a Chart.js option — `maintainAspectRatio: false` does not prevent it:

- `.wrapper` is a column flex with `align-items: center`, so `.canvas-and-slots-container` was **shrink-to-fit**. `canvas { width: 100% }` then degrades to `auto`, and a canvas with an auto width and a definite height resolves against its **intrinsic 2:1 ratio** (the 300×150 default).
- `canvas { margin: 0 auto }` then locked it there: Chart.js `getMaximumSize()` **subtracts the canvas' resolved margins** from the container width, so the centring gutters became permanently unavailable. A manual `chart.resize()` still returned 400 for a 900px container.

### 2. `width` / `height` never invalidated the derived size

`updateComputedDimensions()` ran only from the wrapper's ResizeObserver. `width`/`height` are in `LINE_GRAPH_RECREATE_PROP_NAMES`, so the chart *was* rebuilt — against the stale `computedWidth`/`computedHeight`.

Two symptoms: the Storybook `width`/`height` controls look dead until `browserContainerWidth` is moved, and a container that changes **height only** never re-fits (its wrapper width does not change, so no resize fires). Measured in the tank: cell 264×218, chart frozen at 236×118 — 48% fill.

### 3. CSS `zoom` applied twice

Chart.js measures the container with `getBoundingClientRect()` (zoom-scaled) and writes the number back as an inline CSS-pixel `style` on the canvas, which the browser scales again — the canvas lands at **zoom²** of its cell (64% at `zoom: 0.8`, 156% at `zoom: 1.25`).

Worth stating: `--chart-height` is **not** at fault. `clientWidth` and `ResizeObserver.contentRect` are both zoom-independent; only `getBoundingClientRect()` is scaled. So this is entirely Chart.js' write-back.

This is not an exotic setup — our own `vue-demo` sets `body.style.zoom` from a user-facing 100–200 % setting ([`useComponentSize.ts`](../blob/develop/packages/vue-demo/src/composables/useComponentSize.ts)), pins the "Small Screen" app at `zoom: 1.5`, and ships a `/zoom-calibrate` route.

## Fix

Two files, all changes scoped to `:host([fixedaspectratioscaling])` so pixel-mode consumers are untouched.

**`chart-common.css`**
- `.canvas-and-slots-container { width: 100% }` — a definite box instead of shrink-to-fit.
- `canvas { margin: 0 }` — stop donating the free space to Chart.js' margin subtraction.
- `canvas { width: 100% !important; height: var(--chart-height) !important }` — override Chart.js' inline style. The `!important` is load-bearing and commented as such. Chart.js keeps its own measurement for the drawing buffer, and it converges to the same CSS-pixel size: measured `buffer/csspx = 1.00` at every zoom level, so there is no resolution loss.

**`chart-line-base.ts`**
- Recompute the derived dimensions when `width` / `height` / `fixedAspectRatioScaling` change, before the chart is rebuilt. `updateComputedDimensions()` now returns whether it already rebuilt, so the chart is not built twice.

## Verification

### Sizing matrix (486 cells)

A headless matrix over 18 subjects (gauge-trend × 5 configs, line/area graph in both modes, tank × 6 modes, bar-vertical/horizontal, gauge-vertical/horizontal) × 9 container shapes (fixed ratios 1:2 → 6:1, flex `min-height`/`max-height` + `align-self: center`, grid track, `aspect-ratio`-only, degenerate) × zoom 1 / 0.8 / 1.5. Each cell checks fill, overflow and layout stability (distinct sizes seen by a `ResizeObserver` — the ringing detector from #1121).

Subjects that fill are fed the measured cell size as their aspect-ratio reference, which is the integration `obc-automation-tank` uses; fixed-config gauges and pixel mode own their size by design and are checked for stability only.

| zoom | cells not filling — develop | + clamp fix | + zoom fix |
|---|---|---|---|
| 1 | 33/88 | 0/88 | 0/88 |
| 0.8 | 80/88 | 80/88 | 0/88 |
| 1.5 | 80/88 | 80/88 | 0/88 |
| **all** | **193** | 160 | **0** |
| unstable (>1 size) | 0 | 0 | 0 |

Worst cell on `develop`: 7 % fill. After: none below 99 %.

### End-to-end, the reported shape

A row of `graph-and-bar` tanks plus one wide horizontal tank:

| | before | after |
|---|---|---|
| wide tank, cell 1270×173 | canvas 346×173, **27 % fill** | 1270×173, 100 % |
| portrait tanks | 89 % | 100 % |
| after a height-only row change | 48 % | 100 % |

### Repo suite

- **Full visual suite: 2225 passed, zero baseline changes.** The 11 failures are `graph-mini` / `indicator-graph`, which are uPlot-based, do not touch this CSS, and fail identically on pristine `develop` (confirmed by stashing and re-running).
- `typecheck` clean, `lint` 0 errors (18 pre-existing warnings in unrelated files), `format:check` clean.

## Also in this PR

**Building Blocks → Chart Sizing Battleground** — a live matrix kept in Storybook so this class of regression is visible rather than inferred. Three stories, all `skip-test` (live measurement loops are non-deterministic, and they add no baselines):

- **Container Shapes** — every subject in every shape.
- **Zoom Levels** — a representative set at zoom 0.5 → 2.
- **Resize Stress** — sweeps each cell through five sizes and counts distinct rendered sizes *per step*, so a circular constraint shows up as a count that keeps climbing.

Each cell prints `cell … paint … fills …% sizes … PASS/FAIL`. Through the story itself: Container Shapes 54 → 102 of 103, Zoom Levels 3 → 48 of 48, Resize Stress 0 → 4 of 4.

**`docs/agents/line-area-charts.md`** — a "Fixed-Aspect Sizing" section recording the contract (`width`/`height` are a ratio; the container's height is never consulted; a consumer that wants the chart to fill a box must feed the measured size back, as the tank does) and the three CSS declarations that each look like tidy-up candidates but each silently reintroduce this bug if removed. Plus the measurement rule that bit us: `getBoundingClientRect()` is zoom-scaled, `clientWidth` and `ResizeObserver` `contentRect` are not, so a rect measurement must never be written back as a CSS-pixel style.

**`docs/agents/testing-visual.md`** — "live harness stories" as a category, since the battleground is the first of them. Generated adapters (`.github/instructions`, `.cursor/rules`) refreshed with `npm run agents:sync`; `lint:agents` clean.

## Notes for review

- **One cell in the battleground is red by design** and is documented in the story: `1:2 · tank graph horizontal`. A horizontal tank in a portrait box gets a 30px-wide chart cell, below its own layout minimum, so the chart overflows it. Byte-identical before and after this change (paint 48×437 in both) — a tank layout limit, not chart sizing. Worth a separate issue.
- **Out of contract, unchanged:** in this mode height is still derived from width, and the host's available height is never consulted. The tank works because it feeds its measured cell as the ratio, but a consumer leaving `width`/`height` at the 384×384 default in a wide box will overflow. That is the documented behaviour, so changing it is an API decision rather than a bug fix.
- **vue-demo visual suite not run** — it needs the core build → wrappers → vue build chain. The unchanged core snapshots cover the rendering; worth letting CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart and gauge sizing across varied container shapes and dimensions.
  - Fixed fixed-aspect-ratio layouts so visualizations consistently fill available space.
  - Improved behavior during container resizing, CSS zoom, and animated layout changes.
  - Prevented unnecessary chart redraws when dimensions remain unchanged.

- **Tests**
  - Added visual sizing scenarios covering charts, gauges, and automation tanks across responsive containers, zoom levels, and resize stress conditions.
  - Added reporting to distinguish unavailable space from rendering issues.

- **Documentation**
  - Added guidance for fixed-aspect sizing, zoom behavior, resizing, and visual validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->