### PR TITLE
fix(modal-window): add missing CSS (compared to other containers).

### DIFF
--- a/packages/openbridge-webcomponents/src/components/modal-window/modal-window.css
+++ b/packages/openbridge-webcomponents/src/components/modal-window/modal-window.css
@@ -2,6 +2,10 @@
   box-sizing: border-box;
 }
 
+:host {
+  display: block;
+}
+
 .wrapper {
   box-sizing: border-box;
   background: var(--container-background-color);
@@ -13,6 +17,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
   max-height: 90vh;
 }
 

--- a/packages/openbridge-webcomponents/src/components/modal-window/modal-window.stories.ts
+++ b/packages/openbridge-webcomponents/src/components/modal-window/modal-window.stories.ts
@@ -34,7 +34,9 @@ const meta = {
   },
   decorators: [
     (story) => html`
-      <div style="width: 600px; height: 400px; display: flex;">${story()}</div>
+      <div style="width: 600px; display: flex; align-items: flex-start;">
+        ${story()}
+      </div>
     `,
   ],
 } satisfies Meta<ModalWindowArgs>;
@@ -144,4 +146,36 @@ export const WithoutCancelAndClose: Story = {
     hasCloseAction: false,
     hasOptionalAction: false,
   },
+};
+
+const longContent = html`
+  <div slot="content" style="padding: 24px;">
+    ${Array.from(
+      {length: 12},
+      (_, i) => html`<p>Content paragraph ${i + 1}.</p>`
+    )}
+  </div>
+`;
+
+export const SizedByContainer: Story = {
+  render: (args) => html`
+    <div style="height: 400px; display: flex;">
+      <obc-modal-window
+        .size=${args.size}
+        .hasOptionalAction=${args.hasOptionalAction}
+        .hasLeadingIcon=${args.hasLeadingIcon}
+        .hasCancelAction=${args.hasCancelAction}
+        .hasCloseAction=${args.hasCloseAction}
+      >
+        ${args.hasLeadingIcon
+          ? html`<obi-placeholder slot="leading-icon"></obi-placeholder>`
+          : ''}
+        <span slot="title">Modal Title</span>
+        ${longContent}
+        <span slot="option-label">Option</span>
+        <span slot="cancel-label">Cancel</span>
+        <span slot="done-label">Done</span>
+      </obc-modal-window>
+    </div>
+  `,
 };


### PR DESCRIPTION
Attempt at resolving https://github.com/Ocean-Industries-Concept-Lab/openbridge-webcomponents/issues/1142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved modal layout so it consistently fills available vertical space.
* Ensured modals display correctly as block-level elements.
* Improved behavior when modal content exceeds the height of its container, helping maintain a usable layout in constrained spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->