### PR TITLE
docs(readme): add a plain HTML Hello World getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for bran
 | [docs/agents/](docs/agents/) | Path-scoped rules per component family — the canonical, tool-neutral source for every AI agent. |
 | [IMPLEMENTATION_GUIDELINES.md](IMPLEMENTATION_GUIDELINES.md) | Architecture, PostCSS mixins, SVG practices. |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution workflow and standards. |
+| [Getting Started: HTML](packages/openbridge-webcomponents/README.md#-hello-world) | Tutorial: one HTML file, no build tools — the quickest way to see components running. |
 | [Getting Started: React](docs/getting-started-react.md) | Tutorial: build a multi-view React app with the React wrapper. |
 | [Getting Started: Angular](docs/getting-started-angular.md) | Tutorial: build a multi-view Angular app with the Angular wrapper. |
 | [Charts and Graphs](docs/graph.md) | Custom Chart.js plots with OpenBridge theming. |

--- a/packages/openbridge-webcomponents/README.md
+++ b/packages/openbridge-webcomponents/README.md
@@ -42,6 +42,180 @@ The Live Demo is an application showcase: it shows how components work together 
 | **Stable** (`stable` branch, npm `latest`) | [openbridge-storybook.web.app](https://openbridge-storybook.web.app)           | [openbridge-demo.web.app](https://openbridge-demo.web.app/)           |
 | **Develop** (`develop` branch, npm `next`) | [openbridge-next-storybook.web.app](https://openbridge-next-storybook.web.app) | [openbridge-next-demo.web.app](https://openbridge-next-demo.web.app/) |
 
+## 👋 Hello World
+
+One file, no installation, no build step — a running OpenBridge app with a top
+bar, a side bar and a live instrument.
+
+**You need:** a text editor (Notepad, TextEdit or
+[VS Code](https://code.visualstudio.com/)) and a web browser. No Node.js, no
+terminal.
+
+**1.** Create a file called `hello-openbridge.html`.
+
+**2.** Paste this into it and save:
+
+```html
+<!doctype html>
+<html lang="en" data-obc-theme="day">
+  <head>
+    <meta charset="utf-8" />
+    <title>OpenBridge Hello World</title>
+
+    <!-- The OpenBridge colour palettes -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@oicl/openbridge-webcomponents@next/dist/openbridge.css"
+    />
+    <!-- The font OpenBridge is designed with -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&display=swap"
+    />
+    <!-- Every OpenBridge component, in one file -->
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@oicl/openbridge-webcomponents@next/bundle/openbridge-webcomponents.bundle.js"
+    ></script>
+
+    <style>
+      body {
+        margin: 0;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        font-family: 'Noto Sans', sans-serif;
+        background-color: var(--container-backdrop-color);
+        color: var(--element-active-color);
+      }
+      .row {
+        flex: 1;
+        display: flex;
+      }
+      main {
+        padding: 24px;
+      }
+    </style>
+  </head>
+
+  <body class="obc-component-size-regular">
+    <obc-top-bar
+      apptitle="Hello World"
+      pagename="Compass"
+      showdimmingbutton
+    ></obc-top-bar>
+
+    <div class="row">
+      <obc-navigation-menu>
+        <obc-navigation-item
+          slot="main"
+          label="Compass"
+          href="#"
+          checked
+        ></obc-navigation-item>
+        <obc-navigation-item
+          slot="main"
+          label="Engine"
+          href="#"
+        ></obc-navigation-item>
+        <obc-navigation-item
+          slot="footer"
+          label="Settings"
+          href="#"
+        ></obc-navigation-item>
+      </obc-navigation-menu>
+
+      <main>
+        <obc-compass
+          id="compass"
+          heading="45"
+          style="width: 260px; height: 260px"
+        ></obc-compass>
+        <obc-button id="turn">Turn 15&deg; to starboard</obc-button>
+      </main>
+    </div>
+
+    <script>
+      const topBar = document.querySelector('obc-top-bar');
+      const menu = document.querySelector('obc-navigation-menu');
+      const compass = document.querySelector('#compass');
+
+      // Set a property from JavaScript
+      document.querySelector('#turn').onclick = () => {
+        compass.heading = (compass.heading + 15) % 360;
+      };
+
+      // React to a component event
+      topBar.addEventListener('menu-button-clicked', () => {
+        menu.style.display = menu.style.display === 'none' ? '' : 'none';
+      });
+
+      topBar.addEventListener('dimming-button-clicked', () => {
+        const root = document.documentElement;
+        root.dataset.obcTheme =
+          root.dataset.obcTheme === 'day' ? 'night' : 'day';
+      });
+    </script>
+  </body>
+</html>
+```
+
+**3.** Double-click the file. It opens in your browser and the app is running.
+
+Try it: the button turns the compass, the ☰ button hides the side bar, and the
+dimming button in the top-right switches between the `day` and `night`
+palettes.
+
+If your browser refuses to open a local file like this, put it in its own folder
+and serve that folder instead — `npx serve` if you have Node.js, or the "Live
+Server" extension in VS Code — then open the address it prints.
+
+### The four setup lines
+
+| What                                             | Why                                                                                         |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `openbridge.css`                                 | The colour palettes. Every component takes its colours from here.                           |
+| `data-obc-theme` on `<html>`                     | Which palette: `bright`, `day`, `dusk` or `night`.                                          |
+| `class="obc-component-size-regular"` on `<body>` | How large components are drawn: `regular`, `medium`, `large` or `xl`.                       |
+| The bundle `<script>`                            | Every OpenBridge component. Once it has loaded, tags like `<obc-top-bar>` work on the page. |
+
+### Adding more components
+
+Every component is a tag starting with `obc-`. Find one in
+[Storybook](https://openbridge-next-storybook.web.app), copy its tag and drop it
+in — here a clock, in the top bar's `clock` slot:
+
+```html
+<obc-top-bar
+  apptitle="Hello World"
+  pagename="Compass"
+  showdimmingbutton
+  showclock
+>
+  <obc-clock slot="clock" date="2026-01-01T12:00:00Z"></obc-clock>
+</obc-top-bar>
+```
+
+Two things to know when writing plain HTML:
+
+- Attribute names are all lowercase — the `showDimmingButton` property is
+  written `showdimmingbutton`.
+- Only text and numbers work as attributes. Lists and objects have to be set
+  from JavaScript, the way `compass.heading` is in the script above.
+
+> **Which version?** The example uses the `next` channel because the current
+> `latest` bundle fails to load in a browser. The bundle holds every component
+> (~1.4 MB gzipped), which is ideal for trying things out; for a real
+> application install the package instead, so your build ships only what you
+> use.
+
+When one file is no longer enough, carry on with
+[Installation](#-installation) below, or pick a framework and follow the full
+tutorial for
+[React](https://github.com/Ocean-Industries-Concept-Lab/openbridge-webcomponents/blob/develop/docs/getting-started-react.md)
+or
+[Angular](https://github.com/Ocean-Industries-Concept-Lab/openbridge-webcomponents/blob/develop/docs/getting-started-angular.md).
+
 ## 💾 Installation
 
 To use the components in your project, install the package from npm:
@@ -111,14 +285,19 @@ Use them in your HTML:
 
 ### Bundle Version (CDN / Prototyping)
 
-For quick prototyping, you can use the bundled version:
+For quick prototyping, load the bundled version — every component in a single
+file, straight from a CDN:
 
 ```html
 <script
   type="module"
-  src="node_modules/@oicl/openbridge-webcomponents/dist/openbridge-webcomponents.bundle.js"
+  src="https://cdn.jsdelivr.net/npm/@oicl/openbridge-webcomponents@next/bundle/openbridge-webcomponents.bundle.js"
 ></script>
 ```
+
+From an installed package the same file lives at
+`node_modules/@oicl/openbridge-webcomponents/bundle/openbridge-webcomponents.bundle.js`.
+See [Hello World](#-hello-world) for a complete page built on it.
 
 ## 📦 Framework Wrappers
 

--- a/packages/openbridge-webcomponents/README.md
+++ b/packages/openbridge-webcomponents/README.md
@@ -60,6 +60,7 @@ terminal.
 <html lang="en" data-obc-theme="day">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>OpenBridge Hello World</title>
 
     <!-- The OpenBridge colour palettes -->
@@ -93,7 +94,24 @@ terminal.
         display: flex;
       }
       main {
+        flex: 1;
         padding: 24px;
+      }
+      #compass {
+        width: 260px;
+        height: 260px;
+      }
+      /* On a narrow screen the side bar starts hidden and opens over the page */
+      @media (max-width: 700px) {
+        .row {
+          position: relative;
+        }
+        obc-navigation-menu {
+          display: none;
+          position: absolute;
+          inset: 0 auto 0 0;
+          z-index: 1;
+        }
       }
     </style>
   </head>
@@ -126,11 +144,7 @@ terminal.
       </obc-navigation-menu>
 
       <main>
-        <obc-compass
-          id="compass"
-          heading="45"
-          style="width: 260px; height: 260px"
-        ></obc-compass>
+        <obc-compass id="compass" heading="45"></obc-compass>
         <obc-button id="turn">Turn 15&deg; to starboard</obc-button>
       </main>
     </div>
@@ -147,7 +161,8 @@ terminal.
 
       // React to a component event
       topBar.addEventListener('menu-button-clicked', () => {
-        menu.style.display = menu.style.display === 'none' ? '' : 'none';
+        const hidden = getComputedStyle(menu).display === 'none';
+        menu.style.display = hidden ? 'block' : 'none';
       });
 
       topBar.addEventListener('dimming-button-clicked', () => {
@@ -165,6 +180,11 @@ terminal.
 Try it: the button turns the compass, the ☰ button hides the side bar, and the
 dimming button in the top-right switches between the `day` and `night`
 palettes.
+
+It works on a phone as well. The `viewport` meta tag is what makes the browser
+lay the page out at the real screen width instead of pretending to be a desktop,
+and the one media query in the styles keeps the side bar out of the way until
+☰ is pressed.
 
 If your browser refuses to open a local file like this, put it in its own folder
 and serve that folder instead — `npx serve` if you have Node.js, or the "Live
@@ -200,11 +220,14 @@ Two things to know when writing plain HTML:
 
 - Attribute names are all lowercase — the `showDimmingButton` property is
   written `showdimmingbutton`.
-- Only text and numbers work as attributes. Lists and objects have to be set
-  from JavaScript, the way `compass.heading` is in the script above.
+- Attributes carry simple values only: text, numbers, and on/off flags whose
+  presence means on (`showdimmingbutton`, `checked`). Richer values such as
+  lists and objects have to be set from JavaScript.
 
 > **Which version?** The example uses the `next` channel because the current
-> `latest` bundle fails to load in a browser. The bundle holds every component
+> `latest` bundle fails to load in a browser. A channel always serves the newest
+> release on it, which is what a getting-started page wants; pin an exact
+> version in anything you keep. The bundle holds every component
 > (~1.4 MB gzipped), which is ideal for trying things out; for a real
 > application install the package instead, so your build ships only what you
 > use.


### PR DESCRIPTION
Closes #1159.

The README explained installation and setup but assumed the reader already knew
web tooling. There was no complete starting point for someone who has never used
npm — and no working CDN snippet at all.

## What this adds

A **👋 Hello World** section between "Storybook & Demo" and "Installation": one
self-contained HTML file, loaded from jsDelivr, with a top bar, a side bar, a
compass and a button. Prerequisites are a text editor and a browser — no
Node.js, no terminal, no build step. Save the file, double-click it, done.

The three bits of script are chosen to teach the whole model in a few lines:

- **set a property** — the button turns the compass (`compass.heading = …`)
- **listen to an event** — the ☰ button hides the side bar
- **switch palette** — the dimming button flips `day` ⇄ `night`

Then four short bullets on what each setup line is for, one example of adding
another component (a clock in the top bar's `clock` slot), and the two rules
that trip up plain-HTML users: attribute names are lowercase with no dashes
(`showDimmingButton` → `showdimmingbutton`), and only strings and numbers work
as attributes.

## Two fixes that came out of writing it

**The documented bundle path is wrong.** The Usage section pointed at
`dist/openbridge-webcomponents.bundle.js`, which 404s on both channels — the
file is published under `bundle/`. Corrected, and pointed at the CDN.

**The published `latest` bundle does not load.** 1.0.1's
`bundle/openbridge-webcomponents.bundle.js` has vitest browser-mode code inlined
(51 `vitest` hits) and throws
`vitest/browser can be imported only inside the Browser Mode` during module
evaluation, so every component registered after that point — `obc-top-bar`,
`obc-compass`, … — never defines. `next` is clean; the bundle-entry generator
now ignores `*.spec.ts` / `*.test.ts` / `_test-utils.ts`. That is why the
snippet pins `@next`, with a note in the README saying so. Worth its own issue
and a patch release — happy to file it.

## Verification

The snippet was extracted from the rendered README **verbatim** and run in
Chromium, both from `file://` and over `http://`:

```
definitions: obc-top-bar=ok obc-navigation-menu=ok obc-navigation-item=ok obc-compass=ok obc-button=ok
button label: Turn 15° to starboard
heading 45 -> 60
side bar hidden: true
theme: night
errors: (none)
```

`file://` works because jsDelivr sends `access-control-allow-origin: *`, so the
"just double-click it" instruction holds; a local-server fallback is documented
for browsers that refuse.

## Notes for review

- Pinning `@next` is a deliberate, temporary choice — the note should be removed
  once a 2.x stable ships (or 1.x is repacked).
- The bundle is ~1.4 MB gzipped, called out in the README as prototyping-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Added a browser-only “Hello World” tutorial demonstrating a complete OpenBridge page.
* Documented navigation, compass interaction, menu toggling, and day/night theme switching.
* Added responsive mobile behavior, including adaptive compass sizing and reliable mobile menu toggling.
* Expanded guidance for boolean attributes, CDN channel versioning, and version pinning.
* Added a “Getting Started: HTML” entry to the Documentation Index.
* Updated compass styling and linked to installation and framework tutorials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->